### PR TITLE
Some Zengetters and IIngredient Addition

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntityDefinition.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntityDefinition.java
@@ -34,6 +34,7 @@ public interface IEntityDefinition {
     @ZenMethod
     void clearDrops();
 
+    @ZenGetter("drops")
     List<IEntityDrop> getDrops();
 
     @Deprecated

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntityDefinition.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntityDefinition.java
@@ -2,6 +2,7 @@ package crafttweaker.api.entity;
 
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.WeightedItemStack;
 import crafttweaker.util.IntegerRange;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.*;
@@ -26,7 +27,13 @@ public interface IEntityDefinition {
     void addDrop(IItemStack stack, @Optional int min, @Optional int max, @Optional float chance);
     
     @ZenMethod
+    void addDrop(WeightedItemStack stack, @Optional int min, @Optional int max);
+    
+    @ZenMethod
     void addPlayerOnlyDrop(IItemStack stack, @Optional int min, @Optional int max, @Optional float chance);
+    
+    @ZenMethod
+    void addPlayerOnlyDrop(WeightedItemStack stack, @Optional int min, @Optional int max);
     
     @ZenMethod
     void removeDrop(IItemStack stack);

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntityDrop.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntityDrop.java
@@ -4,20 +4,26 @@ import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.util.IntegerRange;
 import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenGetter;
 
 @ZenClass("crafttweaker.entity.IEntityDrop")
 @ZenRegister
 public interface IEntityDrop {
 
+	@ZenGetter("stack")
 	IItemStack getItemStack();
 
+	@ZenGetter("min")
 	int getMin();
 
+	@ZenGetter("max")
 	int getMax();
 
 	IntegerRange getRange();
 
+	@ZenGetter("chance")
 	float getChance();
 
+	@ZenGetter("playerOnly")
 	boolean isPlayerOnly();
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IIngredient.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IIngredient.java
@@ -53,6 +53,18 @@ public interface IIngredient {
     List<IItemStack> getItems();
     
     /**
+     * Gets all possible items for this ingredient as Array.
+     * <p>
+     * If there is no item list (for example, it is the &lt;*&gt; wildcard item)
+     * an empty Array should be returned
+     * 
+     * @return the items for this ingredient as array, or null
+     */
+    
+    @ZenGetter("itemArray")
+    IItemStack[] getItemArray();
+    
+    /**
      * Gets all possible liquids for this ingredient.
      * <p>
      * If there is no liquid list (for example, it is the &lt;*&ft; wildcard

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientAny.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientAny.java
@@ -36,6 +36,12 @@ public class IngredientAny implements IIngredient {
         return null;
     }
     
+
+	@Override
+	public IItemStack[] getItemArray() {
+		return new IItemStack[]{};
+	}
+    
     @Override
     public List<ILiquidStack> getLiquids() {
         return null;

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientAnyAdvanced.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientAnyAdvanced.java
@@ -39,6 +39,11 @@ public class IngredientAnyAdvanced implements IIngredient {
         return null;
     }
     
+	@Override
+	public IItemStack[] getItemArray() {
+		return new IItemStack[]{};
+	}
+    
     @Override
     public List<ILiquidStack> getLiquids() {
         return null;

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientItem.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientItem.java
@@ -43,6 +43,11 @@ public class IngredientItem implements IIngredient {
         return items;
     }
     
+	@Override
+	public IItemStack[] getItemArray() {
+		return items.toArray(new IItemStack[items.size()]);
+	}
+    
     @Override
     public List<ILiquidStack> getLiquids() {
         return Collections.emptyList();

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientOr.java
@@ -53,6 +53,12 @@ public class IngredientOr implements IIngredient {
         return result;
     }
     
+	@Override
+	public IItemStack[] getItemArray() {
+		List<IItemStack> items = getItems();
+		return items.toArray(new IItemStack[items.size()]);
+	}
+    
     @Override
     public List<ILiquidStack> getLiquids() {
         List<ILiquidStack> result = new ArrayList<>();

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientStack.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientStack.java
@@ -37,6 +37,11 @@ public class IngredientStack implements IIngredient {
     }
     
     @Override
+    public IItemStack[] getItemArray() {
+    	return ingredient.getItemArray();
+    }
+    
+    @Override
     public List<ILiquidStack> getLiquids() {
         return Collections.emptyList();
     }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientUnknown.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientUnknown.java
@@ -34,6 +34,11 @@ public class IngredientUnknown implements IIngredient {
     }
     
     @Override
+    public IItemStack[] getItemArray() {
+    	return new IItemStack[]{};
+    }
+    
+    @Override
     public List<ILiquidStack> getLiquids() {
         return Collections.emptyList();
     }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/oredict/IngredientOreDict.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/oredict/IngredientOreDict.java
@@ -40,6 +40,12 @@ public class IngredientOreDict implements IIngredient {
     }
     
     @Override
+    public IItemStack[] getItemArray() {
+    	List<IItemStack> items = getItems();
+    	return items.toArray(new IItemStack[items.size()]);
+    }
+    
+    @Override
     public List<ILiquidStack> getLiquids() {
         return Collections.emptyList();
     }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/potions/IPotion.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/potions/IPotion.java
@@ -14,5 +14,8 @@ public interface IPotion {
     @ZenGetter("liquidColor")
     int getLiquidColor();
     
+    @ZenGetter("liquidColour")
+    int getLiquidColour();
+    
     Object getInternal();
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/entity/MCEntityDefinition.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/entity/MCEntityDefinition.java
@@ -4,6 +4,7 @@ import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.entity.IEntityDefinition;
 import crafttweaker.api.entity.IEntityDrop;
 import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.WeightedItemStack;
 import crafttweaker.util.IntegerRange;
 import net.minecraft.entity.Entity;
 
@@ -46,6 +47,13 @@ public class MCEntityDefinition implements IEntityDefinition {
         }
         drops.add(new EntityDrop(stack, min, max, chance));
     }
+    
+    @Override
+    public void addDrop(WeightedItemStack stack, int min, int max){
+    	this.addDrop(stack.getStack(), min, max, stack.getChance());
+    }
+    
+
 
     @Override
     public void addPlayerOnlyDrop(IItemStack stack, int min, int max, float chance) {
@@ -54,6 +62,12 @@ public class MCEntityDefinition implements IEntityDefinition {
             return;
         }
         drops.add(new EntityDrop(stack, min, max, chance, true));
+    }
+    
+    @Override
+    public void addPlayerOnlyDrop(WeightedItemStack stack, int min, int max) {
+    	this.addPlayerOnlyDrop(stack.getStack(), min, max, stack.getChance());
+    	
     }
 
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
@@ -227,6 +227,11 @@ public class MCItemStack implements IItemStack {
     }
     
     @Override
+    public IItemStack[] getItemArray() {
+    	return items.toArray(new IItemStack[items.size()]);
+    }
+    
+    @Override
     public List<ILiquidStack> getLiquids() {
         return Collections.emptyList();
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/liquid/MCLiquidStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/liquid/MCLiquidStack.java
@@ -117,6 +117,11 @@ public class MCLiquidStack implements ILiquidStack {
     public List<IItemStack> getItems() {
         return Collections.emptyList();
     }
+    
+    @Override
+    public IItemStack[] getItemArray() {
+    	return new IItemStack[]{};
+    }
 
     @Override
     public List<ILiquidStack> getLiquids() {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
@@ -146,6 +146,12 @@ public class MCOreDictEntry implements IOreDictEntry {
     public List<IItemStack> getItems() {
         return OreDictionary.getOres(getName()).stream().map(CraftTweakerMC::getIItemStackWildcardSize).collect(Collectors.toList());
     }
+    
+    @Override
+    public IItemStack[] getItemArray() {
+    	List<IItemStack> items = getItems();
+    	return items.toArray(new IItemStack[items.size()]);
+    }
 
     @Override
     public List<ILiquidStack> getLiquids() {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/potions/MCPotion.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/potions/MCPotion.java
@@ -27,6 +27,11 @@ public class MCPotion implements IPotion {
     }
     
     @Override
+    public int getLiquidColour() {
+        return potion.getLiquidColor();
+    }
+    
+    @Override
     public Object getInternal() {
         return potion;
     }


### PR DESCRIPTION
Changes:
- Made added drops accessible (mostly for Pack developers to debug CT loot additions)
- Added potion.colo**u**r alias
- Added ingredient.itemArray as Zenscript's ArrayLists currently have no ZenIndexGetter/-Setter

As I didnt't change much I believe everything should still work properly (even though I laid my hands on it).