### PR TITLE
Fixed hiding with WILDCARD metadata

### DIFF
--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/Classes/Hide.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/Classes/Hide.java
@@ -31,9 +31,8 @@ public class Hide implements IAction {
         }
         
         
-        // TODO make it work for OreDictionary.WILDCARD meta values
         ItemStack IStack = getItemStack(stack);
-        JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(ItemStack.class, Collections.singletonList(IStack));
+        JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(ItemStack.class, JEIAddonPlugin.getSubTypes(IStack));
 
     }
     


### PR DESCRIPTION
Fixed hiding with WILDCARD metadata using the same method as 1.11.2 used that was left and unused in the port