### PR TITLE
A little of everything

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/data/IData.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/data/IData.java
@@ -124,9 +124,11 @@ public interface IData {
     @ZenOperator(OperatorType.INDEXSET)
     void setAt(int i, IData value);
     
+    @ZenMethod
     @ZenMemberGetter
     IData memberGet(String name);
     
+    @ZenMethod
     @ZenMemberSetter
     void memberSet(String name, IData data);
     

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/data/IData.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/data/IData.java
@@ -47,27 +47,35 @@ public interface IData {
     IData not();
     
     @ZenCaster
+    @ZenMethod
     boolean asBool();
     
     @ZenCaster
+    @ZenMethod
     byte asByte();
     
     @ZenCaster
+    @ZenMethod
     short asShort();
     
     @ZenCaster
+    @ZenMethod
     int asInt();
     
     @ZenCaster
+    @ZenMethod
     long asLong();
     
     @ZenCaster
+    @ZenMethod
     float asFloat();
     
     @ZenCaster
+    @ZenMethod
     double asDouble();
     
     @ZenCaster
+    @ZenMethod
     String asString();
     
     /**
@@ -77,6 +85,7 @@ public interface IData {
      * @return list data of this value, if any
      */
     @ZenCaster
+    @ZenMethod
     List<IData> asList();
     
     /**
@@ -86,6 +95,7 @@ public interface IData {
      * @return map data of this value, if any
      */
     @ZenCaster
+    @ZenMethod
     Map<String, IData> asMap();
     
     /**
@@ -95,6 +105,7 @@ public interface IData {
      * @return byte array data of this value, if any
      */
     @ZenCaster
+    @ZenMethod
     byte[] asByteArray();
     
     /**
@@ -104,6 +115,7 @@ public interface IData {
      * @return int array data of this value, if any
      */
     @ZenCaster
+    @ZenMethod
     int[] asIntArray();
     
     @ZenOperator(OperatorType.INDEXGET)

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemStack.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemStack.java
@@ -251,6 +251,7 @@ public interface IItemStack extends IIngredient {
      * @return block, or null if this item is not a block
      */
     @ZenCaster
+    @ZenMethod
     IBlock asBlock();
     
     /**

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/oredict/IOreDict.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/oredict/IOreDict.java
@@ -12,7 +12,8 @@ import java.util.List;
 @ZenRegister
 public interface IOreDict {
     
-    @ZenMemberGetter
+	@ZenMethod
+	@ZenMemberGetter
     IOreDictEntry get(String name);
     
     @ZenGetter("entries")

--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionArithmeticUnary.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionArithmeticUnary.java
@@ -31,7 +31,7 @@ public class ExpressionArithmeticUnary extends Expression {
             ZenType type = base.getType();
             if(type == ZenType.BOOL) {
                 if(operator == OperatorType.NOT) {
-                    output.iNot();
+                    output.iXorVs1();
                     return;
                 }
             } else if(type == ZenTypeByte.INSTANCE || type == ZenTypeShort.INSTANCE || type == ZenTypeInt.INSTANCE) {

--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionMapIndexSet.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionMapIndexSet.java
@@ -39,6 +39,7 @@ public class ExpressionMapIndexSet extends Expression {
         if(result) {
             map.compile(result, environment);
             index.compile(result, environment);
+            value.compile(result, environment);
             environment.getOutput().invokeInterface(internal(Map.class), "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
         }
     }

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/ZenType.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/ZenType.java
@@ -350,6 +350,6 @@ public abstract class ZenType {
     
     @Override
     public boolean equals(Object other) {
-        return other instanceof ZenType && getName().equals(((ZenType) other).getName());
+        return other instanceof ZenType && (getName().equals(((ZenType) other).getName()) || toJavaClass().equals(((ZenType) other).toJavaClass()));
     }
 }

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/ZenTypeFunction.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/ZenTypeFunction.java
@@ -50,8 +50,14 @@ public class ZenTypeFunction extends ZenType {
         
         StringBuilder nameBuilder = new StringBuilder();
         nameBuilder.append("function(");
+        boolean first = true;
         for(ZenType type : argumentTypes) {
-            nameBuilder.append(type.getName());
+            if(first) {
+                first = false;
+            } else {
+                nameBuilder.append(',');
+            }
+        	nameBuilder.append(type.getName());
         }
         nameBuilder.append(')');
         nameBuilder.append(returnType.getName());

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/ZenTypeIntRange.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/ZenTypeIntRange.java
@@ -147,7 +147,7 @@ public class ZenTypeIntRange extends ZenType {
     
     @Override
     public String getName() {
-        return "int..";
+        return "stanhebben.zenscript.value.IntRange";
     }
     
     @Override

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
@@ -42,9 +42,11 @@ public class JavaMethod implements IJavaMethod {
             }
         }
         
+        /*
         if(method.isVarArgs()) {
             optional[parameterTypes.length - 1] = true;
         }
+        */
     }
     
     public static IJavaMethod get(ITypeRegistry types, Class cls, String name, Class... parameterTypes) {
@@ -143,7 +145,7 @@ public class JavaMethod implements IJavaMethod {
         
         int doUntil = parameterTypes.length;
         if(method.isVarargs()) {
-            doUntil = arguments.length - 1;
+            doUntil = parameterTypes.length - 1;
             ZenType paramType = parameterTypes[parameterTypes.length - 1];
             ZenType baseType = ((ZenTypeArray) paramType).getBaseType();
             
@@ -165,7 +167,7 @@ public class JavaMethod implements IJavaMethod {
                 for(int i = 0; i < values.length; i++) {
                     values[i] = arguments[offset + i].cast(position, environment, baseType);
                 }
-                result[arguments.length - 1] = new ExpressionArray(position, (ZenTypeArrayBasic) paramType, values);
+                result[offset] = new ExpressionArray(position, (ZenTypeArrayBasic) paramType, values);
             }
         }
         
@@ -253,7 +255,7 @@ public class JavaMethod implements IJavaMethod {
             
             int checkUntil = parameterTypes.length;
             if(method.isVarArgs()) {
-                checkUntil--;
+                //checkUntil--;
             }
             for(int i = arguments.length; i < checkUntil; i++) {
                 if(!optional[i]) {
@@ -263,6 +265,7 @@ public class JavaMethod implements IJavaMethod {
         }
         
         int checkUntil = arguments.length;
+        if (method.isVarArgs()) checkUntil = parameterTypes.length - 1;
         if(arguments.length == parameterTypes.length && method.isVarArgs()) {
             ZenType arrayType = parameterTypes[method.getParameterTypes().length - 1];
             ZenType baseType = ((ZenTypeArray) arrayType).getBaseType();

--- a/ZenScript/src/main/java/stanhebben/zenscript/util/MethodOutput.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/util/MethodOutput.java
@@ -364,6 +364,14 @@ public class MethodOutput {
         visitor.visitInsn(IXOR);
     }
     
+    public void iXorVs1() {
+    	if(debug)
+            System.out.println("iXor against '1'");
+        
+        visitor.visitInsn(ICONST_1);
+        visitor.visitInsn(IXOR);   
+    }
+    
     public void iShr() {
         if(debug)
             System.out.println("iShr");

--- a/ZenScript/src/main/java/stanhebben/zenscript/util/StringUtil.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/util/StringUtil.java
@@ -2,6 +2,7 @@ package stanhebben.zenscript.util;
 
 import stanhebben.zenscript.expression.Expression;
 import stanhebben.zenscript.type.ZenType;
+import stanhebben.zenscript.type.ZenTypeNative;
 import stanhebben.zenscript.type.natives.*;
 
 import java.lang.annotation.Annotation;
@@ -84,9 +85,12 @@ public class StringUtil {
                             Annotation an = m.getMethod().getParameterAnnotations()[i][i1];
                             message.append("\u00a7a").append(an.annotationType().getSimpleName()).append(" ");
                         }
-                        message.append("\u00a7r").append(type.getClass().getSimpleName()).append(", ");
+                        message.append("\u00a7r").append(type.toString()).append(", ");
                     }
-                    message.deleteCharAt(message.lastIndexOf(", "));
+                    
+                    //Removes last ', ' and closes the bracket
+                    message.deleteCharAt(message.length()-1);
+                    message.deleteCharAt(message.length()-1);
                     message.append(")");
                 }
             });


### PR DESCRIPTION
### Summary of changes
1. Added `@ZenMethod` annotation to some ZenCasters
2. Added `@ZenMethod` annotation to some ZenMemberGetters and ZenMemberSetters

### Reason for changes
1. ZenCasters don't work, this way people can at least use IData Correctly and convert IItemStacks to IBlocks
2. This facilitates the use of more advanced loops as people can now do e.g. `oreDict.get(name);`

### Does this break anything?
Shouldn't break anything as I only added annotations, never removed any