### PR TITLE
Improve performance of ActionRemoveRecipesNoIngredients

### DIFF
--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
@@ -132,6 +132,7 @@ public class CraftTweaker {
         try {
             MCRecipeManager.recipes = ForgeRegistries.RECIPES.getEntries();
             MCRecipeManager.recipesToRemove.forEach(CraftTweakerAPI::apply);
+            MCRecipeManager.actionRemoveRecipesNoIngredients.apply();
             MCRecipeManager.recipesToAdd.forEach(CraftTweakerAPI::apply);
             MCFurnaceManager.recipesToRemove.forEach(CraftTweakerAPI::apply);
             MCFurnaceManager.recipesToAdd.forEach(CraftTweakerAPI::apply);

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeManager.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeManager.java
@@ -9,6 +9,7 @@ import crafttweaker.api.recipes.*;
 import crafttweaker.mc1120.CraftTweaker;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
+import javafx.util.Pair;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.InventoryCrafting;
@@ -35,6 +36,7 @@ public final class MCRecipeManager implements IRecipeManager {
     public static Set<Map.Entry<ResourceLocation, IRecipe>> recipes;
     public final static List<ActionBaseAddRecipe> recipesToAdd = new ArrayList<>();
     public final static List<ActionBaseRemoveRecipes> recipesToRemove = new ArrayList<>();
+    public final static ActionRemoveRecipesNoIngredients actionRemoveRecipesNoIngredients = new ActionRemoveRecipesNoIngredients();
     private static TIntSet usedHashes = new TIntHashSet();
     private static HashSet<String> usedRecipeNames = new HashSet<>();
     
@@ -158,7 +160,7 @@ public final class MCRecipeManager implements IRecipeManager {
     
     @Override
     public void remove(IIngredient output, @Optional boolean nbtMatch) {
-        recipesToRemove.add(new ActionRemoveRecipesNoIngredients(output, nbtMatch));
+        actionRemoveRecipesNoIngredients.addOutput(output, nbtMatch);
     }
     
     @Override
@@ -427,40 +429,42 @@ public final class MCRecipeManager implements IRecipeManager {
     }
     
     public static class ActionRemoveRecipesNoIngredients extends ActionBaseRemoveRecipes {
-        
-        IIngredient output;
-        boolean nbtMatch;
-        
-        public ActionRemoveRecipesNoIngredients(IIngredient output, @Optional boolean nbtMatch) {
-            this.output = output;
-            this.nbtMatch = nbtMatch;
+        // pair of output, nbtMatch
+        private final List<Pair<IIngredient, Boolean>> outputs = new ArrayList<>();
+
+        public void addOutput(IIngredient output, @Optional boolean nbtMatch) {
+            outputs.add(new Pair<>(output, nbtMatch));
         }
         
         @Override
         public void apply() {
-            if(output == null) {
-                return;
-            }
             List<ResourceLocation> toRemove = new ArrayList<>();
             
             for(Map.Entry<ResourceLocation, IRecipe> recipe : recipes) {
-                if(!recipe.getValue().getRecipeOutput().isEmpty()) {
-                    if(nbtMatch ? output.matchesExact(getIItemStack(recipe.getValue().getRecipeOutput())) : output.matches(getIItemStack(recipe.getValue().getRecipeOutput()))) {
-                        toRemove.add(recipe.getKey());
-                    }
+                ItemStack recipeOutput = recipe.getValue().getRecipeOutput();
+                IItemStack stack = getIItemStack(recipeOutput);
+                if(stack != null && matches(stack)) {
+                    toRemove.add(recipe.getKey());
                 }
             }
             
             super.removeRecipes(toRemove);
         }
+
+        private boolean matches(IItemStack stack) {
+            for(Pair<IIngredient, Boolean> entry : outputs) {
+                IIngredient output = entry.getKey();
+                Boolean nbtMatch = entry.getValue();
+                if(nbtMatch ? output.matchesExact(stack) : output.matches(stack)) {
+                    return true;
+                }
+            }
+            return false;
+        }
         
         @Override
         public String describe() {
-            if(output != null) {
-                return "Removing all recipes for " + output.toString();
-            } else {
-                return "Trying to remove recipes for invalid output";
-            }
+            return "Removing recipes for various outputs";
         }
     }
     

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEI.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEI.java
@@ -10,9 +10,6 @@ import stanhebben.zenscript.annotations.*;
 
 import java.util.*;
 
-import static crafttweaker.mc1120.recipes.MCRecipeManager.recipesToRemove;
-
-
 /**
  * MineTweaker JEI support.
  * <p>
@@ -38,7 +35,7 @@ public class JEI {
     
     @ZenMethod
     public static void removeAndHide(IIngredient output, @Optional boolean nbtMatch) {
-        recipesToRemove.add(new MCRecipeManager.ActionRemoveRecipesNoIngredients(output, nbtMatch));
+        MCRecipeManager.actionRemoveRecipesNoIngredients.addOutput(output, nbtMatch);
         for(IItemStack stack : output.getItems()) {
             LATE_ACTIONS.add(new Hide(stack));
         }


### PR DESCRIPTION
Before:
![crt-pr-before](https://user-images.githubusercontent.com/916092/33226257-5a686958-d13e-11e7-8aef-04bf82202992.png)

After:
![crt-pr-after](https://user-images.githubusercontent.com/916092/33226258-5dda768a-d13e-11e7-9153-37de301a64a0.png)

uhh seems almost too fast now but the code looks right.