### PR TITLE
ZenNativeCasters and Better ArrayAdd

### DIFF
--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionArrayAdd.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionArrayAdd.java
@@ -1,77 +1,44 @@
 package stanhebben.zenscript.expression;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-
 import stanhebben.zenscript.compiler.IEnvironmentGlobal;
 import stanhebben.zenscript.compiler.IEnvironmentMethod;
 import stanhebben.zenscript.type.ZenType;
 import stanhebben.zenscript.type.ZenTypeArrayBasic;
+import stanhebben.zenscript.util.ArrayUtil;
 import stanhebben.zenscript.util.MethodOutput;
 import stanhebben.zenscript.util.ZenPosition;
-import stanhebben.zenscript.util.ZenTypeUtil;
 
 public class ExpressionArrayAdd extends Expression {
-	
-	private final Expression array, value;
-	private final ZenTypeArrayBasic type;
 
-	public ExpressionArrayAdd(ZenPosition position, IEnvironmentGlobal environment, Expression array, Expression val) {
-		super(position);
-		this.array = array;
-		this.value = val;
-		this.type = (ZenTypeArrayBasic) array.getType();
-	}
+    private final Expression array, value;
+    private final ZenTypeArrayBasic type;
 
-	@Override
-	public ZenType getType() {
-		return type;
-	}
+    public ExpressionArrayAdd(ZenPosition position, IEnvironmentGlobal environment, Expression array, Expression val) {
+        super(position);
+        this.array = array;
+        this.value = val;
+        this.type = (ZenTypeArrayBasic) array.getType();
+    }
 
-	@Override
-	public void compile(boolean result, IEnvironmentMethod environment) {
-		
-		MethodOutput output = environment.getOutput();
-		/*
-		output.newObject(ArrayList.class);
-		output.dup();
-		array.compile(true, environment);
-		output.invokeStatic(Arrays.class, "asList", List.class, Object[].class);
+    @Override
+    public ZenType getType() {
+        return type;
+    }
 
-		output.construct(ArrayList.class, Collection.class);
-		output.dup();
-		value.cast(getPosition(), environment, ZenTypeUtil.checkPrimitive(type.getBaseType())).compile(true, environment);
-		output.invokeInterface(List.class, "add", boolean.class, Object.class);
-		output.pop();
-		output.invokeInterface(List.class, "toArray", Object[].class, new Class<?>[]{});
-		*/
-		
-		
-		//Old Array
-		array.compile(true, environment);
-		output.dup();
-		output.arrayLength();
-		output.iConst1();
-		output.iAdd();
+    @Override
+    public void compile(boolean result, IEnvironmentMethod environment) {
+        MethodOutput output = environment.getOutput();
 
+        array.compile(true, environment);
+        value.cast(getPosition(), environment, type.getBaseType()).compile(true, environment);
 
-		if (type.getBaseType().toJavaClass().isPrimitive()) {
-			Class<?> arrayType = getType().toJavaClass();
-			output.invokeStatic(Arrays.class, "copyOf", arrayType, arrayType, int.class);
-		} else {
-			output.invokeStatic(Arrays.class, "copyOf", Object[].class, Object[].class, int.class);
-		}
-
-		output.dup();
-		output.dup();
-		output.arrayLength();
-		output.iConst1();
-		output.iSub();
-		value.cast(getPosition(), environment, type.getBaseType()).compile(true, environment);
-		output.arrayStore(type.getBaseType().toASMType());
-		output.checkCast(type.getSignature());
-	}
+        if (type.getBaseType().toJavaClass().isPrimitive()) {
+            Class<?> arrayType = getType().toJavaClass();
+            output.invokeStatic(ArrayUtil.class, "add", arrayType, arrayType, type.getBaseType().toJavaClass());
+        } else {
+            output.invokeStatic(ArrayUtil.class, "add", Object[].class, Object[].class, Object.class);
+            output.checkCast(type.getSignature());
+        }
+    }
 
 }

--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionArrayAdd.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionArrayAdd.java
@@ -32,7 +32,9 @@ public class ExpressionArrayAdd extends Expression {
 
 	@Override
 	public void compile(boolean result, IEnvironmentMethod environment) {
+		
 		MethodOutput output = environment.getOutput();
+		/*
 		output.newObject(ArrayList.class);
 		output.dup();
 		array.compile(true, environment);
@@ -44,6 +46,32 @@ public class ExpressionArrayAdd extends Expression {
 		output.invokeInterface(List.class, "add", boolean.class, Object.class);
 		output.pop();
 		output.invokeInterface(List.class, "toArray", Object[].class, new Class<?>[]{});
+		*/
+		
+		
+		//Old Array
+		array.compile(true, environment);
+		output.dup();
+		output.arrayLength();
+		output.iConst1();
+		output.iAdd();
+
+
+		if (type.getBaseType().toJavaClass().isPrimitive()) {
+			Class<?> arrayType = getType().toJavaClass();
+			output.invokeStatic(Arrays.class, "copyOf", arrayType, arrayType, int.class);
+		} else {
+			output.invokeStatic(Arrays.class, "copyOf", Object[].class, Object[].class, int.class);
+		}
+
+		output.dup();
+		output.dup();
+		output.arrayLength();
+		output.iConst1();
+		output.iSub();
+		value.cast(getPosition(), environment, type.getBaseType()).compile(true, environment);
+		output.arrayStore(type.getBaseType().toASMType());
+		output.checkCast(type.getSignature());
 	}
 
 }

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/ZenTypeArray.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/ZenTypeArray.java
@@ -93,8 +93,6 @@ public abstract class ZenTypeArray extends ZenType {
         if(operator == OperatorType.INDEXGET) {
             return indexGet(position, environment, left, right);
         } else if (operator == OperatorType.ADD) {
-        	if (getBaseType().toJavaClass().isArray()) throw new UnsupportedOperationException("You cannot add to nested arrays!");
-        	if (getBaseType().toJavaClass().isPrimitive()) throw new UnsupportedOperationException("You cannot add to primitive arrays!");
         	if (!getBaseType().equals(right.getType()) && !right.getType().canCastExplicit(getBaseType(), environment)) throw new IllegalArgumentException(String.format("Cannot add %s to %s", right.getType().toString(), toString()));
         	
         	return add(position, environment, left, right);

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/expand/ZenExpandCaster.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/expand/ZenExpandCaster.java
@@ -1,11 +1,15 @@
 package stanhebben.zenscript.type.expand;
 
 import stanhebben.zenscript.compiler.IEnvironmentGlobal;
-import stanhebben.zenscript.expression.*;
+import stanhebben.zenscript.expression.Expression;
+import stanhebben.zenscript.expression.ExpressionCallStatic;
 import stanhebben.zenscript.type.ZenType;
-import stanhebben.zenscript.type.casting.*;
+import stanhebben.zenscript.type.casting.CastingRuleDelegateStaticMethod;
+import stanhebben.zenscript.type.casting.CastingRuleStaticMethod;
+import stanhebben.zenscript.type.casting.ICastingRuleDelegate;
 import stanhebben.zenscript.type.natives.IJavaMethod;
-import stanhebben.zenscript.util.*;
+import stanhebben.zenscript.util.MethodOutput;
+import stanhebben.zenscript.util.ZenPosition;
 
 /**
  * @author Stanneke

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/natives/ZenNativeCaster.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/natives/ZenNativeCaster.java
@@ -3,38 +3,45 @@ package stanhebben.zenscript.type.natives;
 import org.objectweb.asm.Label;
 import stanhebben.zenscript.compiler.IEnvironmentGlobal;
 import stanhebben.zenscript.type.ZenType;
+import stanhebben.zenscript.type.casting.CastingRuleVirtualMethod;
+import stanhebben.zenscript.type.casting.ICastingRuleDelegate;
 import stanhebben.zenscript.util.MethodOutput;
 
 /**
  * @author Stanneke
  */
 public class ZenNativeCaster {
-    
+
     private final IJavaMethod method;
-    
+
     public ZenNativeCaster(IJavaMethod method) {
         this.method = method;
     }
-    
+
     public ZenType getReturnType() {
         return method.getReturnType();
     }
-    
+
+    public void constructCastingRule(ICastingRuleDelegate rules) {
+        ZenType type = getReturnType();
+        rules.registerCastingRule(type, new CastingRuleVirtualMethod(method));
+    }
+
     public void compile(MethodOutput output) {
-        if(method.isStatic()) {
+        if (method.isStatic()) {
             method.invokeStatic(output);
         } else {
             method.invokeVirtual(output);
         }
     }
-    
+
     public void compileAnyCanCastImplicit(ZenType type, MethodOutput output, IEnvironmentGlobal environment, int localClass) {
         String casterAny = method.getReturnType().getAnyClassName(environment);
-        if(casterAny == null) {
+        if (casterAny == null) {
             // TODO: make sure no type ever does this
             return;
         }
-        
+
         Label skip = new Label();
         output.loadObject(localClass);
         output.invokeStatic(casterAny, "rtCanCastImplicit", "(Ljava/lang/Class;)Z");
@@ -43,32 +50,32 @@ public class ZenNativeCaster {
         output.returnInt();
         output.label(skip);
     }
-    
+
     public void compileAnyCast(ZenType type, MethodOutput output, IEnvironmentGlobal environment, int localValue, int localClass) {
         Label skip = new Label();
         output.loadObject(localClass);
         output.constant(method.getReturnType().toASMType());
         output.ifACmpNe(skip);
         output.load(type.toASMType(), localValue);
-        
+
         compile(output);
-        
+
         output.returnType(method.getReturnType().toASMType());
         output.label(skip);
-        
+
         String casterAny = method.getReturnType().getAnyClassName(environment);
-        if(casterAny == null)
+        if (casterAny == null)
             // TODO: make sure this isn't necessary
             return;
-        
+
         Label skip2 = new Label();
         output.loadObject(localClass);
         output.invokeStatic(casterAny, "rtCanCastImplicit", "(Ljava/lang/Class;)Z");
         output.ifEQ(skip2);
         output.load(type.toASMType(), localValue);
-        
+
         compile(output);
-        
+
         output.returnType(method.getReturnType().toASMType());
         output.label(skip2);
     }

--- a/ZenScript/src/main/java/stanhebben/zenscript/util/ArrayUtil.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/util/ArrayUtil.java
@@ -1,0 +1,69 @@
+package stanhebben.zenscript.util;
+
+import java.util.Arrays;
+
+public class ArrayUtil {
+
+    public static boolean[] add(boolean[] array, boolean item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+
+    public static byte[] add(byte[] array, byte item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+
+    public static char[] add(char[] array, char item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+
+    public static double[] add(double[] array, double item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+
+    public static float[] add(float[] array, float item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+
+    public static int[] add(int[] array, int item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+
+    public static long[] add(long[] array, long item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+
+    public static short[] add(short[] array, short item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+
+    public static <T> T[] add(T[] array, T item) {
+        int size = array.length;
+        array = Arrays.copyOfRange(array, 0, size + 1);
+        array[size] = item;
+        return array;
+    }
+}


### PR DESCRIPTION
ZenNativeCasts should work now (e.g. `<minecraft:grass> as IBlock;`)
Casting from the new type would require double-casting (e.g. `<minecraft:grass> as IBlock as IBlockPattern;`

ArrayAdd now uses its own Util Method, so that the generated bytecode is reduced (now it only consists of arrayCompile, valueCompile, call to UtilClass and, if the type was not a primitive array, a cast to the new arrayType)