### PR TITLE
See Desc

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockDefinition.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockDefinition.java
@@ -35,6 +35,9 @@ public interface IBlockDefinition {
     @ZenSetter("hardness")
     void setHardness(float hardness);
     
+    @ZenGetter("hardness")
+    float getHardness();
+    
     @ZenMethod
     void setUnbreakable();
     
@@ -45,7 +48,7 @@ public interface IBlockDefinition {
     void setTickRandomly(boolean tickRandomly);
     
     @ZenMethod
-    void setHarvestLevel(String toolclass, int level);
+    void setHarvestLevel(String toolClass, int level);
     
     @ZenGetter("harvestLevel")
     int getHarvestLevel();

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemDefinition.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemDefinition.java
@@ -90,5 +90,8 @@ public interface IItemDefinition {
     @ZenMethod
     void setContainerItem(IItemDefinition item);
     
+    @ZenGetter("subItems")
+    List<IItemStack> getSubItems();
+    
     Object getInternal();
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemDefinition.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemDefinition.java
@@ -93,5 +93,8 @@ public interface IItemDefinition {
     @ZenGetter("subItems")
     List<IItemStack> getSubItems();
     
+    @ZenMethod
+    List<IItemStack> getSubItems(ICreativeTab tab);
+    
     Object getInternal();
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptFile.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptFile.java
@@ -2,6 +2,7 @@ package crafttweaker.runtime;
 
 import crafttweaker.api.network.NetworkSide;
 import crafttweaker.preprocessor.IPreprocessor;
+import crafttweaker.runtime.providers.ScriptIteratorZip;
 
 import java.io.*;
 import java.util.*;
@@ -57,8 +58,9 @@ public class ScriptFile {
      * Gets the effective name that has every info in it that it can, like zip files don't use only the zip file name
      */
     public String getEffectiveName(){
-        if (script.getGroupName().endsWith(".zip")) {
-            return getGroupName() + "$" + getName();
+        if (script instanceof ScriptIteratorZip) {
+            ScriptIteratorZip scriptIterator = (ScriptIteratorZip) script;
+            return getGroupName() + "\\" + scriptIterator.getCurrentName().replace('/', '\\');
         }else {
             return getGroupName();
         }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/providers/ScriptIteratorZip.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/providers/ScriptIteratorZip.java
@@ -57,6 +57,10 @@ public class ScriptIteratorZip implements IScriptIterator {
         entries = entriesList.iterator();
     }
     
+    public String getCurrentName() {
+        return current.getName();
+    }
+    
     @Override
     public String getGroupName() {
         if(file != null && directory != null) {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockDefinition.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockDefinition.java
@@ -12,6 +12,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import java.util.Optional;
+
 /**
  * @author Stan
  */
@@ -94,7 +96,7 @@ public class MCBlockDefinition implements IBlockDefinition {
     
     @Override
     public String getHarvestTool() {
-        return block.getHarvestTool(block.getDefaultState());
+        return Optional.ofNullable(block.getHarvestTool(block.getDefaultState())).orElse("");
     }
     
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockDefinition.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockDefinition.java
@@ -63,6 +63,11 @@ public class MCBlockDefinition implements IBlockDefinition {
     }
     
     @Override
+    public float getHardness() {
+        return block.blockHardness;
+    }
+    
+    @Override
     public void setUnbreakable() {
         block.setBlockUnbreakable();
     }
@@ -78,8 +83,8 @@ public class MCBlockDefinition implements IBlockDefinition {
     }
     
     @Override
-    public void setHarvestLevel(String toolclass, int level) {
-        block.setHarvestLevel(toolclass, level);
+    public void setHarvestLevel(String toolClass, int level) {
+        block.setHarvestLevel(toolClass, level);
     }
     
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemDefinition.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemDefinition.java
@@ -8,10 +8,12 @@ import crafttweaker.api.oredict.IOreDictEntry;
 import crafttweaker.mc1120.creativetabs.MCCreativeTab;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.*;
+import net.minecraft.util.NonNullList;
 import net.minecraftforge.oredict.OreDictionary;
 import stanhebben.zenscript.annotations.Optional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author Stan
@@ -110,6 +112,13 @@ public class MCItemDefinition implements IItemDefinition {
     @Override
     public void setContainerItem(IItemDefinition itemDef) {
         item.setContainerItem((Item) itemDef.getInternal());
+    }
+    
+    @Override
+    public List<IItemStack> getSubItems () {
+        NonNullList<ItemStack> list = NonNullList.create();
+        item.getSubItems(item.getCreativeTab(), list);
+        return list.stream().map(MCItemStack::new).collect(Collectors.toList());
     }
     
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemDefinition.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemDefinition.java
@@ -116,8 +116,13 @@ public class MCItemDefinition implements IItemDefinition {
     
     @Override
     public List<IItemStack> getSubItems () {
+        return getSubItems(getCreativeTab());
+    }
+    
+    @Override
+    public List<IItemStack> getSubItems(ICreativeTab tab) {
         NonNullList<ItemStack> list = NonNullList.create();
-        item.getSubItems(item.getCreativeTab(), list);
+        item.getSubItems((CreativeTabs) tab.getInternal(), list);
         return list.stream().map(MCItemStack::new).collect(Collectors.toList());
     }
     

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
@@ -102,7 +102,7 @@ public class MCItemStack implements IItemStack {
     
     @Override
     public float getBlockHardness() {
-        return ReflectionHelper.getPrivateValue(Block.class, Block.getBlockFromItem(stack.getItem()), "blockHardness", "field_149782_v");
+        return Block.getBlockFromItem(stack.getItem()).blockHardness;
     }
     
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
@@ -102,7 +102,7 @@ public class MCItemStack implements IItemStack {
     
     @Override
     public float getBlockHardness() {
-        return ReflectionHelper.getPrivateValue(Block.class, Block.getBlockFromItem(stack.getItem()), "blockHardness");
+        return ReflectionHelper.getPrivateValue(Block.class, Block.getBlockFromItem(stack.getItem()), "blockHardness", "field_149782_v");
     }
     
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
@@ -50,7 +50,12 @@ public class MCOreDictEntry implements IOreDictEntry {
 
     @Override
     public IItemStack getFirstItem() {
-        return getItems().get(0);
+        List<IItemStack> items = getItems();
+        if (items.isEmpty()) {
+            CraftTweakerAPI.logInfo("No first item found for oredict " + getName() + "replacing with null reference");
+            return null;
+        }
+        return items.get(0);
     }
 
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
@@ -52,7 +52,7 @@ public class MCOreDictEntry implements IOreDictEntry {
     public IItemStack getFirstItem() {
         List<IItemStack> items = getItems();
         if (items.isEmpty()) {
-            CraftTweakerAPI.logInfo("No first item found for oredict " + getName() + "replacing with null reference");
+            CraftTweakerAPI.logInfo("No first item found for oredict " + getName() + "! Replacing with null reference");
             return null;
         }
         return items.get(0);

--- a/CraftTweaker2-MC1120-Main/src/main/resources/META-INF/crafttweaker_at.cfg
+++ b/CraftTweaker2-MC1120-Main/src/main/resources/META-INF/crafttweaker_at.cfg
@@ -6,3 +6,4 @@ public net.minecraft.util.text.translation.LanguageMap field_74817_a #instance
 public net.minecraft.util.text.translation.I18n field_74839_a #localizedName
 public net.minecraft.util.text.translation.LanguageMap field_74816_c #languageList
 public-f net.minecraft.client.entity.EntityPlayerSP field_192036_cb #recipeBook
+public net.minecraft.block.Block field_149782_v #blockHardness

--- a/ZenScript/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -122,6 +122,8 @@ public class ZenModule {
                         fn.getReturnType().defaultValue(fn.getPosition()).compile(true, methodEnvironment);
                         methodOutput.returnType(fn.getReturnType().toASMType());
                     }
+                } else if(!(statements[statements.length - 1] instanceof StatementReturn)) {
+                    methodOutput.ret();
                 }
                 methodOutput.end();
             }

--- a/ZenScript/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -84,7 +84,11 @@ public class ZenModule {
             }
             
             if(!script.getFunctions().isEmpty() || !script.getGlobals().isEmpty()) {
-                String[] splitName = script.getFileName().split("\\.|\\\\");
+                String fileName = script.getFileName();
+                if (fileName.startsWith("scripts.zip\\"))
+                    fileName = fileName.substring(12);
+                
+                String[] splitName = fileName.replaceAll("\\.zip", "").split("\\.|\\\\");
                 PartialScriptReference reference = SymbolScriptReference.getOrCreateReference(environmentGlobal);
                 if(splitName.length != 0)
                     reference.addScriptOrDirectory(environmentScript, Arrays.copyOfRange(splitName, 0, splitName.length - 1));

--- a/ZenScript/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -343,7 +343,7 @@ public class ZenModule {
             dir = "";
         }
         
-        return dir.length() > 0 ? (dir.replace("/", "_") + "_") : "" + StringUtil.capitalize(name);
+        return (dir.length() > 0 ? dir.replace('/', '\\') + "\\" : "") + StringUtil.capitalize(name);
         
     }
     

--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionStringMethod.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionStringMethod.java
@@ -33,14 +33,7 @@ public class ExpressionStringMethod implements IPartialExpression {
     
     public static boolean hasMethod(String name, ITypeRegistry typeRegistry) {
         if(!initialised) {
-            for(Method method : String.class.getMethods()) {
-                if(checkMethod(method)) {
-                    String methodName = method.getName();
-                    members.putIfAbsent(methodName, new ZenNativeMember());
-                    members.get(methodName).addMethod(new JavaMethod(method, typeRegistry));
-                }
-            }
-            initialised = true;
+            initialise(typeRegistry);
         }
         return members.containsKey(name);
     }
@@ -52,6 +45,17 @@ public class ExpressionStringMethod implements IPartialExpression {
                 return false;
         }
         return (method.getReturnType().isAssignableFrom(char.class) || method.getReturnType().isAssignableFrom(char[].class)) ? false : (method.getModifiers() & Opcodes.ACC_STATIC) == 0;
+    }
+    
+    private static void initialise(ITypeRegistry typeRegistry) {
+        for(Method method : String.class.getMethods()) {
+            if(checkMethod(method)) {
+                String methodName = method.getName();
+                members.putIfAbsent(methodName, new ZenNativeMember());
+                members.get(methodName).addMethod(new JavaMethod(method, typeRegistry));
+            }
+        }
+        initialised = true;
     }
     
     @Override

--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionStringMethod.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionStringMethod.java
@@ -1,48 +1,105 @@
 package stanhebben.zenscript.expression;
 
-import java.lang.reflect.Method;
-
-import stanhebben.zenscript.compiler.IEnvironmentGlobal;
-import stanhebben.zenscript.compiler.IEnvironmentMethod;
+import org.objectweb.asm.Opcodes;
+import stanhebben.zenscript.compiler.*;
+import stanhebben.zenscript.expression.partial.IPartialExpression;
+import stanhebben.zenscript.symbols.IZenSymbol;
 import stanhebben.zenscript.type.ZenType;
+import stanhebben.zenscript.type.natives.*;
 import stanhebben.zenscript.util.ZenPosition;
 
-public class ExpressionStringMethod extends Expression{
+import java.lang.reflect.Method;
+import java.util.*;
 
-	private final Expression source;
-	private final String methodName;
-	private final Class<?> returnClass;
-	private final ZenType type;
-	
-	public ExpressionStringMethod(ZenPosition position, Expression expression, String method, IEnvironmentGlobal environment) {
-		super(position);
-		this.source = expression;
-		this.methodName = method;
-		this.returnClass = getMethod(method).getReturnType();
-		this.type = environment.getType(returnClass);
-	}
+import static stanhebben.zenscript.util.StringUtil.methodMatchingError;
 
-	@Override
-	public ZenType getType() {
-		return type;
-	}
-
-	@Override
-	public void compile(boolean result, IEnvironmentMethod environment) {
-		source.compile(result, environment);
-		environment.getOutput().invokeVirtual(String.class, methodName, returnClass);
-	}
-
-	private static Method getMethod(String name) {
-		try {
-			return String.class.getMethod(name);
-		} catch (NoSuchMethodException e) {
-			return null;
-		}
-	}
-	
-	public static boolean hasMethod(String name) {
-		return getMethod(name) != null;
-	}
-
+public class ExpressionStringMethod implements IPartialExpression {
+    
+    private static final Map<String, ZenNativeMember> members = new HashMap<>();
+    private static boolean initialised = false;
+    
+    private final ZenPosition position;
+    private final Expression source;
+    private final String methodName;
+    private final List<IJavaMethod> methods;
+    
+    
+    public ExpressionStringMethod(ZenPosition position, Expression expression, String method) {
+        this.position = position;
+        this.source = expression;
+        this.methodName = method;
+        this.methods = members.get(method).getMethods();
+    }
+    
+    public static boolean hasMethod(String name, ITypeRegistry typeRegistry) {
+        if(!initialised) {
+            for(Method method : String.class.getMethods()) {
+                if(checkMethod(method)) {
+                    String methodName = method.getName();
+                    members.putIfAbsent(methodName, new ZenNativeMember());
+                    members.get(methodName).addMethod(new JavaMethod(method, typeRegistry));
+                }
+            }
+            initialised = true;
+        }
+        return members.containsKey(name);
+    }
+    
+    //No statics and no characters (ZS doesn't know latter)
+    private static boolean checkMethod(Method method) {
+        for(Class<?> parameter : method.getParameterTypes()) {
+            if(parameter.isAssignableFrom(char.class) || parameter.isAssignableFrom(char[].class))
+                return false;
+        }
+        return (method.getReturnType().isAssignableFrom(char.class) || method.getReturnType().isAssignableFrom(char[].class)) ? false : (method.getModifiers() & Opcodes.ACC_STATIC) == 0;
+    }
+    
+    @Override
+    public ZenType getType() {
+        return ZenType.ANY;
+    }
+    
+    @Override
+    public ZenType toType(IEnvironmentGlobal environment) {
+        return ZenType.ANY;
+    }
+    
+    @Override
+    public Expression eval(IEnvironmentGlobal environment) {
+        environment.error(position, "Cannot evaluate a StringMethod");
+        return new ExpressionInvalid(position);
+    }
+    
+    @Override
+    public Expression assign(ZenPosition position, IEnvironmentGlobal environment, Expression other) {
+        environment.error(position, "Cannot assign to a String method");
+        return new ExpressionInvalid(position);
+    }
+    
+    @Override
+    public IPartialExpression getMember(ZenPosition position, IEnvironmentGlobal environment, String name) {
+        environment.error(position, "Cannot get the member of a String method");
+        return new ExpressionInvalid(position);
+    }
+    
+    @Override
+    public Expression call(ZenPosition position, IEnvironmentMethod environment, Expression... values) {
+        IJavaMethod method = JavaMethod.select(false, methods, environment, values);
+        if(method == null) {
+            environment.error(position, methodMatchingError(methods, values));
+            return new ExpressionInvalid(position);
+        } else {
+            return new ExpressionCallVirtual(position, environment, method, source.eval(environment), values);
+        }
+    }
+    
+    @Override
+    public ZenType[] predictCallTypes(int numArguments) {
+        return JavaMethod.predict(members.get(methodName).getMethods(), numArguments);
+    }
+    
+    @Override
+    public IZenSymbol toSymbol() {
+        throw new UnsupportedOperationException("Cannot get a symbol from a String method");
+    }
 }

--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionStringMethod.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionStringMethod.java
@@ -70,8 +70,8 @@ public class ExpressionStringMethod implements IPartialExpression {
     
     @Override
     public Expression eval(IEnvironmentGlobal environment) {
-        for (IJavaMethod method : methods) {
-            if (method.accepts(0)) {
+        for(IJavaMethod method : methods) {
+            if(method.accepts(0)) {
                 return new ExpressionCallVirtual(position, environment, method, source.eval(environment), new Expression[0]);
             }
         }

--- a/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionStringMethod.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/expression/ExpressionStringMethod.java
@@ -70,6 +70,12 @@ public class ExpressionStringMethod implements IPartialExpression {
     
     @Override
     public Expression eval(IEnvironmentGlobal environment) {
+        for (IJavaMethod method : methods) {
+            if (method.accepts(0)) {
+                return new ExpressionCallVirtual(position, environment, method, source.eval(environment), new Expression[0]);
+            }
+        }
+        
         environment.error(position, "Cannot evaluate a StringMethod");
         return new ExpressionInvalid(position);
     }

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/ZenType.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/ZenType.java
@@ -229,7 +229,7 @@ public abstract class ZenType {
     }
     
     public final boolean canCastImplicit(ZenType type, IEnvironmentGlobal environment) {
-        return equals(type) || getCastingRule(type, environment) != null || toJavaClass().isInstance(type.toJavaClass());
+        return this.equals(type) || this.getCastingRule(type, environment) != null || type.toJavaClass().isAssignableFrom(this.toJavaClass());
         
     }
     

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/ZenTypeString.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/ZenTypeString.java
@@ -20,6 +20,7 @@ public class ZenTypeString extends ZenType {
     
     public static final ZenTypeString INSTANCE = new ZenTypeString();
     
+    
     private static final String ANY_NAME = "any/AnyString";
     private static final String ANY_NAME_2 = "any.AnyString";
     
@@ -85,11 +86,11 @@ public class ZenTypeString extends ZenType {
     
     @Override
     public IPartialExpression getMember(ZenPosition position, IEnvironmentGlobal environment, IPartialExpression value, String name) {
-    	if(ExpressionStringMethod.hasMethod(name)) {
-    		return new ExpressionStringMethod(position, value.eval(environment), name, environment);
-    	}
-    	
-    	IPartialExpression result = memberExpansion(position, environment, value.eval(environment), name);
+        if(ExpressionStringMethod.hasMethod(name, environment.getEnvironment().getTypeRegistry())) {
+            return new ExpressionStringMethod(position, value.eval(environment), name);
+        }
+        
+        IPartialExpression result = memberExpansion(position, environment, value.eval(environment), name);
         if(result == null) {
             environment.error(position, "string value has no such member: " + name);
             return new ExpressionInvalid(position, ZenTypeAny.INSTANCE);

--- a/ZenScript/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
+++ b/ZenScript/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
@@ -60,11 +60,11 @@ public class JavaMethod implements IJavaMethod {
     public static IJavaMethod getStatic(String owner, String name, ZenType returnType, ZenType... arguments) {
         return new JavaMethodGenerated(true, false, false, owner, name, returnType, arguments, new boolean[arguments.length]);
     }
-
+    
     public static IJavaMethod get(ITypeRegistry types, Method method) {
         return new JavaMethod(method, types);
     }
-
+    
     public static IJavaMethod select(boolean doStatic, List<IJavaMethod> methods, IEnvironmentGlobal environment, Expression... arguments) {
         int bestPriority = PRIORITY_INVALID;
         IJavaMethod bestMethod = null;
@@ -86,7 +86,7 @@ public class JavaMethod implements IJavaMethod {
         
         return isValid ? bestMethod : null;
     }
-
+    
     public static ZenType[] predict(List<IJavaMethod> methods, int numArguments) {
         ZenType[] results = new ZenType[numArguments];
         boolean[] ambiguous = new boolean[numArguments];
@@ -256,7 +256,8 @@ public class JavaMethod implements IJavaMethod {
         }
         
         int checkUntil = arguments.length;
-        if (method.isVarArgs()) checkUntil = parameterTypes.length - 1;
+        if(method.isVarArgs())
+            checkUntil = parameterTypes.length - 1;
         if(arguments.length == parameterTypes.length && method.isVarArgs()) {
             ZenType arrayType = parameterTypes[method.getParameterTypes().length - 1];
             ZenType baseType = ((ZenTypeArray) arrayType).getBaseType();


### PR DESCRIPTION
- All String methods except for those requiring java's char primitive now work
- ItemDefinition.subItems
- Now use access transformer for BlockHardness
- Object parameters work again (ZS can cast to object again, though users cannot!)
- oreDictEntry#firstItem now logs a warning and returns null if the OD doesnt contain items
- ZenScript internals:
  - Void functions now don't need a return statement
  - Globals and script references:
    - Globals in subfolders now work and generated classfiles now represent the fodler structure (don't ask me how or why, java Opcode is strange and I have no idea why it works)
    - scripts in `scripts\scripts.zip` are handled the same as scripts in `scripts\` by the reference system (so users can simply compress their scripts folder and put it in the scripts folder)
    - `.zip` is filtered out from filenames in the script reference builder