### PR TITLE
Adding recipes.replaceAllOccurences(IIngredient,IIngredient) as a new zenscript command

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/recipes/IRecipeManager.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/recipes/IRecipeManager.java
@@ -188,5 +188,8 @@ public interface IRecipeManager {
      */
     @ZenMethod
     IItemStack craft(IItemStack[][] contents);
-    
+
+
+    @ZenMethod
+    void replaceAllOccurences(IIngredient toReplace, IIngredient replaceWith);
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeManager.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeManager.java
@@ -302,7 +302,8 @@ public final class MCRecipeManager implements IRecipeManager {
                                 targRow[i] = replaceWith;
                         }
                     }
-                    MCRecipeManager.recipesToAdd.add(new ActionAddShapedRecipe(recipe.getName()+"-modified",recipe.output,ingredients,recipe.recipeFunction,recipe.recipeAction,false,recipe.hidden));
+                    String proposedName = recipe.getRegistryName().getResourceDomain()+"-"+recipe.getName()+"-modified";
+                    MCRecipeManager.recipesToAdd.add(new ActionAddShapedRecipe(proposedName,recipe.output,ingredients,recipe.recipeFunction,recipe.recipeAction,false,recipe.hidden));
                 }
                 else
                 {
@@ -314,8 +315,8 @@ public final class MCRecipeManager implements IRecipeManager {
                             ingredients[i] =replaceWith;
                         }
                     }
-                    new ActionAddShapelessRecipe(recipe.getOutput(),ingredients,recipe.recipeFunction,recipe.getRecipeAction());
-                    MCRecipeManager.recipesToAdd.add( new ActionAddShapelessRecipe(recipe.getName()+"-modified", recipe.getOutput(),ingredients,recipe.recipeFunction,recipe.getRecipeAction(),recipe.hidden));
+                    String proposedName = recipe.getRegistryName().getResourceDomain()+"-"+recipe.getName()+"-modified";
+                    MCRecipeManager.recipesToAdd.add( new ActionAddShapelessRecipe( proposedName, recipe.getOutput(),ingredients,recipe.recipeFunction,recipe.getRecipeAction(),recipe.hidden));
                 }
             }
 


### PR DESCRIPTION
The command will search through all vanilla style recipes for any recipe containing the first ingredient, remove that recipe, and create a new recipe that is identical, except the second ingredient has been substituted for the first.

I feel this will be useful in cases such as replacing all Machine Frames from one mod to another, or (the case that made me write this) switching all Industrial Foregoing recipes to use Pneumaticraft Plastic instead of IF Plastic.

Please let me know if you simply don't like the idea, or see anything you would want changed before being able to accept this pull request, and I'll get right on it.