### PR TITLE
[Incomplete] Loader aliases and RecipeBook fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 CraftTweaker2-MC1120-Tests/run/
 CraftTweaker2-MC1120-Tests/server/
 /CraftTweaker2-MC1120-Tests/.gradle/
+desktop.ini

--- a/CraftTweaker2-API/src/main/java/crafttweaker/CraftTweakerAPI.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/CraftTweakerAPI.java
@@ -192,6 +192,14 @@ public class CraftTweakerAPI {
         getLogger().logError(message, exception);
     }
     
+    /**
+     * Logs an info message, but only if it has not been disabled
+     * @param message info message
+     */
+    public static void logDefault(String message) {
+        getLogger().logDefault(message);
+    }
+    
     // ###################################
     // ### Plugin registration methods ###
     // ###################################

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientOr.java
@@ -206,4 +206,9 @@ public class IngredientOr implements IIngredient {
         }
         return commandString.toString();
     }
+
+    @Override
+    public String toString() {
+        return toCommandString();
+    }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/logger/FileLogger.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/logger/FileLogger.java
@@ -15,6 +15,7 @@ public class FileLogger implements ILogger {
     private static final Pattern FORMATTING_CODE_PATTERN = Pattern.compile("(?i)" + String.valueOf('\u00a7') + "[0-9A-FK-OR]");
     private final Writer writer;
     private final PrintWriter printWriter;
+    private boolean isDefaultDisabled = false;
     
     public FileLogger(File output) {
         try {
@@ -85,5 +86,21 @@ public class FileLogger implements ILogger {
      */
     public String stripMessage(String message) {
         return message == null ? null : FORMATTING_CODE_PATTERN.matcher(message).replaceAll("");
+    }
+    
+    @Override
+    public void logDefault(String message) {
+        if(!isLogDisabled())
+            logInfo(message);
+    }
+    
+    @Override
+    public boolean isLogDisabled() {
+        return isDefaultDisabled;
+    }
+    
+    @Override
+    public void setLogDisabled(boolean logDisabled) {
+        this.isDefaultDisabled = logDisabled;
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/logger/MTLogger.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/logger/MTLogger.java
@@ -14,6 +14,7 @@ public class MTLogger implements ILogger {
     private final List<ILogger> loggers = new ArrayList<>();
     private final List<IPlayer> players = new ArrayList<>();
     private final List<String> unprocessed = new ArrayList<>();
+    private boolean isDefaultDisabled = false;
     
     public void addLogger(ILogger logger) {
         loggers.add(logger);
@@ -98,5 +99,21 @@ public class MTLogger implements ILogger {
     @Override
     public void logPlayer(IPlayer player) {
     
+    }
+    
+    @Override
+    public void logDefault(String message) {
+        if(!isLogDisabled())
+            logInfo(message);
+    }
+    
+    @Override
+    public boolean isLogDisabled() {
+        return isDefaultDisabled;
+    }
+    
+    @Override
+    public void setLogDisabled(boolean logDisabled) {
+        this.isDefaultDisabled = logDisabled;
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
@@ -120,7 +120,7 @@ public class CrTTweaker implements ITweaker {
         
         loader.setLoaderStage(ScriptLoader.LoaderStage.LOADING);
         if(!isLinter)
-            CRT_LOADING_STARTED_EVENT_EVENT_LIST.publish(new CrTLoadingStartedEvent(loader, networkSide, isSyntaxCommand));
+            CRT_LOADING_STARTED_EVENT_EVENT_LIST.publish(new CrTLoadingStartedEvent(loader, isSyntaxCommand, networkSide));
         
         preprocessorManager.clean();
         

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
@@ -326,6 +326,7 @@ public class CrTTweaker implements ITweaker {
                     mergeLoader = loader;
                 } else {
                     mergeLoader.addAliases(loader.getNames().toArray(new String[0]));
+                    mergeLoader.setMainName(loader.getMainName());
                     it.remove();
                 }
             }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
@@ -112,6 +112,11 @@ public class CrTTweaker implements ITweaker {
             return false;
         }
         
+        if(loader.getLoaderStage() == ScriptLoader.LoaderStage.INVALIDATED) {
+            CraftTweakerAPI.logWarning("Skipping loading for loader " + loader + " since it's become invalidated");
+            return false;
+        }
+        
         
         loader.setLoaderStage(ScriptLoader.LoaderStage.LOADING);
         if(!isLinter)
@@ -332,8 +337,9 @@ public class CrTTweaker implements ITweaker {
                 } else {
                     mergeLoader.addAliases(loader.getNames().toArray(new String[0]));
                     mergeLoader.setMainName(loader.getMainName());
-                    if(loader.getLoaderStage() != ScriptLoader.LoaderStage.NOT_LOADED)
+                    if(loader.getLoaderStage() != ScriptLoader.LoaderStage.NOT_LOADED && loader.getLoaderStage() != ScriptLoader.LoaderStage.INVALIDATED)
                         mergeLoader.setLoaderStage(loader.getLoaderStage());
+                    loader.setLoaderStage(ScriptLoader.LoaderStage.INVALIDATED);
                     it.remove();
                 }
             }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
@@ -108,7 +108,7 @@ public class CrTTweaker implements ITweaker {
         
         CraftTweakerAPI.logInfo("Loading scripts for loader with names " + loader.toString());
         if(loader.isLoaded() && !isSyntaxCommand) {
-            CraftTweakerAPI.logInfo("Skipping loading for loader " + loader + " since it's already been loaded");
+            CraftTweakerAPI.logDefault("Skipping loading for loader " + loader + " since it's already been loaded");
             return false;
         }
         
@@ -144,13 +144,13 @@ public class CrTTweaker implements ITweaker {
             
             
             if(!loader.canExecute(scriptFile.getLoaderName()) && !isSyntaxCommand) {
-                CraftTweakerAPI.logInfo(getTweakerDescriptor(loaderName) + ": Skipping file " + scriptFile + " as we are currently loading with a different loader");
+                CraftTweakerAPI.logDefault(getTweakerDescriptor(loaderName) + ": Skipping file " + scriptFile + " as we are currently loading with a different loader");
                 continue;
             }
             
             // check for network side
             if(!scriptFile.shouldBeLoadedOn(networkSide)) {
-                CraftTweakerAPI.logInfo(getTweakerDescriptor(loaderName) + ": Skipping file " + scriptFile + " as we are on the wrong side of the Network");
+                CraftTweakerAPI.logDefault(getTweakerDescriptor(loaderName) + ": Skipping file " + scriptFile + " as we are on the wrong side of the Network");
                 continue;
             }
             
@@ -158,7 +158,7 @@ public class CrTTweaker implements ITweaker {
             if(!executed.contains(scriptFile.getEffectiveName())) {
                 executed.add(scriptFile.getEffectiveName());
                 
-                CraftTweakerAPI.logInfo(getTweakerDescriptor(loaderName) + ": Loading Script: " + scriptFile);
+                CraftTweakerAPI.logDefault(getTweakerDescriptor(loaderName) + ": Loading Script: " + scriptFile);
                 
                 ZenParsedFile zenParsedFile = null;
                 String filename = scriptFile.getEffectiveName();
@@ -218,7 +218,7 @@ public class CrTTweaker implements ITweaker {
                 
                 if(!isLinter)
                     CRT_LOADING_SCRIPT_POST_EVENT_LIST.publish(new CrTLoadingScriptEventPost(filename));
-                //                CraftTweakerAPI.logInfo("Completed file: " + filename +" in: " + (System.currentTimeMillis() - time) + "ms");
+                    //CraftTweakerAPI.logDefault("Completed file: " + filename +" in: " + (System.currentTimeMillis() - time) + "ms");
             }
             
         }
@@ -233,7 +233,7 @@ public class CrTTweaker implements ITweaker {
         
         
         loader.setLoaderStage(loadSuccessful ? ScriptLoader.LoaderStage.LOADED_SUCCESSFUL : ScriptLoader.LoaderStage.ERROR);
-        CraftTweakerAPI.logInfo("Completed script loading in: " + (System.currentTimeMillis() - totalTime) + "ms");
+        CraftTweakerAPI.logDefault("Completed script loading in: " + (System.currentTimeMillis() - totalTime) + "ms");
         return loadSuccessful;
     }
     
@@ -350,7 +350,7 @@ public class CrTTweaker implements ITweaker {
             loaders.add(mergeLoader);
         }
         
-        CraftTweakerAPI.logInfo("Current loaders after merging: " + loaders);
+        CraftTweakerAPI.logDefault("Current loaders after merging: " + loaders);
         return mergeLoader;
     }
     

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/CrTTweaker.java
@@ -95,6 +95,11 @@ public class CrTTweaker implements ITweaker {
         return loadScript(isSyntaxCommand, parseExceptions, isLinter, loaderName);
     }
     
+    @Override
+    public void loadScript(boolean isSyntaxCommand, ScriptLoader loader) {
+        loadScript(isSyntaxCommand, loader, null, false);
+    }
+    
     private boolean loadScript(boolean isSyntaxCommand, ScriptLoader loader, List<SingleError> parseExceptions, boolean isLinter) {
         if(loader == null) {
             CraftTweakerAPI.logError("Error when trying to load with a null loader");
@@ -130,7 +135,7 @@ public class CrTTweaker implements ITweaker {
         long totalTime = System.currentTimeMillis();
         for(ScriptFile scriptFile : scriptFiles) {
             // check for loader
-            final String loaderName = loader.getNames().iterator().next();
+            final String loaderName = loader.getMainName();
             
             
             if(!loader.canExecute(scriptFile.getLoaderName()) && !isSyntaxCommand) {
@@ -294,7 +299,7 @@ public class CrTTweaker implements ITweaker {
         CRT_LOADING_SCRIPT_POST_EVENT_LIST.add(eventHandler);
     }
     
-    public ScriptLoader getLoader(String... names) {
+    private ScriptLoader getLoader(String... names) {
         for(ScriptLoader loader : loaders) {
             if(loader.canExecute(names))
                 return loader;
@@ -302,18 +307,18 @@ public class CrTTweaker implements ITweaker {
         return null;
     }
     
-    public ScriptLoader getOrAddLoader(String... names) {
+    private ScriptLoader getOrAddLoader(String... names) {
         ScriptLoader loader = getLoader(names);
         if(loader != null)
             return loader;
-        return addLoader(names);
+        return getOrCreateLoader(names);
     }
     
     /**
      * Adds a loader, merges with other Lists if possible
      */
     @Override
-    public ScriptLoader addLoader(String... nameAndAliases) {
+    public ScriptLoader getOrCreateLoader(String... nameAndAliases) {
         Iterator<ScriptLoader> it = loaders.iterator();
         ScriptLoader mergeLoader = null;
         
@@ -327,6 +332,8 @@ public class CrTTweaker implements ITweaker {
                 } else {
                     mergeLoader.addAliases(loader.getNames().toArray(new String[0]));
                     mergeLoader.setMainName(loader.getMainName());
+                    if(loader.getLoaderStage() != ScriptLoader.LoaderStage.NOT_LOADED)
+                        mergeLoader.setLoaderStage(loader.getLoaderStage());
                     it.remove();
                 }
             }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ILogger.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ILogger.java
@@ -1,7 +1,7 @@
 package crafttweaker.runtime;
 
 import crafttweaker.api.player.IPlayer;
-import stanhebben.zenscript.annotations.ZenMethod;
+import stanhebben.zenscript.annotations.*;
 
 /**
  * @author Stan
@@ -25,4 +25,13 @@ public interface ILogger {
     
     @ZenMethod
     void logPlayer(IPlayer player);
+    
+    @ZenMethod
+    void logDefault(String message);
+    
+    @ZenGetter("logDisabled")
+    boolean isLogDisabled();
+    
+    @ZenSetter("logDisabled")
+    void setLogDisabled(boolean logDisabled);
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ITweaker.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ITweaker.java
@@ -90,4 +90,5 @@ public interface ITweaker {
      */
     void registerScriptLoadPostEvent(IEventHandler<CrTLoadingScriptEventPost> eventHandler);
     
+    ScriptLoader addLoader(String... nameAndAliases);
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ITweaker.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ITweaker.java
@@ -44,6 +44,9 @@ public interface ITweaker {
      * @return Whether it was successful at loading or not
      */
     boolean loadScript(boolean isSyntaxCommand, String loaderName);
+    
+    
+    void loadScript(boolean isSyntaxCommand, ScriptLoader loader);
 
 
     /**
@@ -102,8 +105,9 @@ public interface ITweaker {
     
     /**
      * Gets or adds a new loader
+     * Be careful as this loader might become invalidated if merged with another loader so always call this method anew if possible.
      * @param nameAndAliases the Names the loader will be callable under, if an existing loader already has any of the names, they will be merged
      * @return The added, retrieved or changed loader
      */
-    ScriptLoader addLoader(String... nameAndAliases);
+    ScriptLoader getOrCreateLoader(String... nameAndAliases);
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ITweaker.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ITweaker.java
@@ -76,19 +76,34 @@ public interface ITweaker {
     /**
      * Gets called as soon as the script start getting loaded (before the zs files are getting loaded)
      */
-    void registerLoadStartedEvent(IEventHandler<CrTLoadingStartedEvent> eventHandler);
+    void registerLoadStartedEvent(IEventHandler<CrTLoaderLoadingEvent.Started> eventHandler);
+    
+    /**
+     * Gets called once the loader has finished loading
+     */
+    void registerLoadFinishedEvent(IEventHandler<CrTLoaderLoadingEvent.Finished> eventHandler);
+    
+    /**
+     * Gets called if the loader was aborted for any reason
+     */
+    void registerLoadAbortedEvent(IEventHandler<CrTLoaderLoadingEvent.Aborted> eventHandler);
     
     
     /**
      * Gets called just before the script file is loaded
      */
-    void registerScriptLoadPreEvent(IEventHandler<CrTLoadingScriptEventPre> eventHandler);
+    void registerScriptLoadPreEvent(IEventHandler<CrTScriptLoadingEvent.Pre> eventHandler);
     
     
     /**
      * Gets called as soon as the script file is done loading.
      */
-    void registerScriptLoadPostEvent(IEventHandler<CrTLoadingScriptEventPost> eventHandler);
+    void registerScriptLoadPostEvent(IEventHandler<CrTScriptLoadingEvent.Post> eventHandler);
     
+    /**
+     * Gets or adds a new loader
+     * @param nameAndAliases the Names the loader will be callable under, if an existing loader already has any of the names, they will be merged
+     * @return The added, retrieved or changed loader
+     */
     ScriptLoader addLoader(String... nameAndAliases);
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 public class ScriptLoader {
     
+    private String mainName;
     private final Set<String> names = new HashSet<>();
     private LoaderStage loaderStage = LoaderStage.NOT_LOADED;
     
@@ -16,6 +17,14 @@ public class ScriptLoader {
     
     public Set<String> getNames() {
         return names;
+    }
+    
+    public String getMainName() {
+        return mainName != null ? mainName : names.iterator().next();
+    }
+    
+    public void setMainName(String mainName) {
+        this.mainName = mainName;
     }
     
     public boolean isLoaded() {

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
@@ -20,10 +20,14 @@ public class ScriptLoader {
     }
     
     public String getMainName() {
-        return mainName != null ? mainName : names.iterator().next();
+        if(mainName == null)
+            mainName = names.iterator().next();
+        return mainName;
     }
     
     public void setMainName(String mainName) {
+        if(!canExecute(mainName))
+            addAliases(mainName);
         this.mainName = mainName;
     }
     
@@ -44,12 +48,14 @@ public class ScriptLoader {
             CraftTweakerAPI.logInfo("Trying to add loader aliases [" + String.join(" | ", names) + "] to already loaded ScriptLoader " + this.toString());
         
         for(String name : names)
-            this.names.add(name.toLowerCase());
+            this.names.add(name.trim().toLowerCase());
+        if(this.names.isEmpty())
+            throw new IllegalArgumentException("Loader is empty after all aliases have been added");
     }
     
     public boolean canExecute(String... loaderNames) {
         for(String loaderName : loaderNames) {
-            if(names.contains(loaderName.toLowerCase()))
+            if(names.contains(loaderName.trim().toLowerCase()))
                 return true;
         }
         return false;
@@ -57,7 +63,16 @@ public class ScriptLoader {
     
     @Override
     public String toString() {
-        return "[" + String.join(" | ", names) + "]";
+        StringJoiner joiner = new StringJoiner(" | ", "[", "]");
+    
+        final String mainName = getMainName();
+        joiner.add(mainName);
+        for(String name : names) {
+            if(!mainName.equals(name))
+                joiner.add(name);
+        }
+        
+        return joiner.toString();
     }
     
     

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
@@ -32,7 +32,7 @@ public class ScriptLoader {
     
     public void addAliases(String... names) {
         if(isLoaded())
-            CraftTweakerAPI.logInfo("Trying to add loader aliases [" + String.join(" | ", names) + "] to already loaderStage ScriptLoader " + this.toString());
+            CraftTweakerAPI.logInfo("Trying to add loader aliases [" + String.join(" | ", names) + "] to already loaded ScriptLoader " + this.toString());
         
         for(String name : names)
             this.names.add(name.toLowerCase());

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
@@ -1,0 +1,44 @@
+package crafttweaker.runtime;
+
+import java.util.*;
+
+public class ScriptLoader {
+    
+    private final Set<String> names = new HashSet<>();
+    private boolean loaded = false;
+    
+    public ScriptLoader(String... nameAndAliases) {
+        addAliases(nameAndAliases);
+    }
+    
+    
+    public Set<String> getNames() {
+        return names;
+    }
+    
+    public boolean isLoaded() {
+        return loaded;
+    }
+    
+    public void setLoaded(boolean loaded) {
+        this.loaded = loaded;
+    }
+    
+    public void addAliases(String... names) {
+        this.names.addAll(Arrays.asList(names));
+    }
+    
+    public boolean canExecute(String... loaderNames) {
+        for(String loaderName : loaderNames) {
+            if(names.contains(loaderName))
+                return true;
+        }
+        return false;
+    }
+    
+    @Override
+    public String toString() {
+        return "[" + String.join(" | ", names) + "]";
+    }
+    
+}

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
@@ -77,7 +77,7 @@ public class ScriptLoader {
     
     
     public enum LoaderStage {
-        NOT_LOADED, LOADING, LOADED_SUCCESSFUL, ERROR, UNKNOWN
+        NOT_LOADED, LOADING, LOADED_SUCCESSFUL, ERROR, INVALIDATED, UNKNOWN
     }
     
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/ScriptLoader.java
@@ -1,11 +1,13 @@
 package crafttweaker.runtime;
 
+import crafttweaker.CraftTweakerAPI;
+
 import java.util.*;
 
 public class ScriptLoader {
     
     private final Set<String> names = new HashSet<>();
-    private boolean loaded = false;
+    private LoaderStage loaderStage = LoaderStage.NOT_LOADED;
     
     public ScriptLoader(String... nameAndAliases) {
         addAliases(nameAndAliases);
@@ -17,20 +19,28 @@ public class ScriptLoader {
     }
     
     public boolean isLoaded() {
-        return loaded;
+        return loaderStage != LoaderStage.NOT_LOADED;
     }
     
-    public void setLoaded(boolean loaded) {
-        this.loaded = loaded;
+    public LoaderStage getLoaderStage() {
+        return loaderStage;
+    }
+    
+    public void setLoaderStage(LoaderStage loaderStage) {
+        this.loaderStage = loaderStage;
     }
     
     public void addAliases(String... names) {
-        this.names.addAll(Arrays.asList(names));
+        if(isLoaded())
+            CraftTweakerAPI.logInfo("Trying to add loader aliases [" + String.join(" | ", names) + "] to already loaderStage ScriptLoader " + this.toString());
+        
+        for(String name : names)
+            this.names.add(name.toLowerCase());
     }
     
     public boolean canExecute(String... loaderNames) {
         for(String loaderName : loaderNames) {
-            if(names.contains(loaderName))
+            if(names.contains(loaderName.toLowerCase()))
                 return true;
         }
         return false;
@@ -39,6 +49,11 @@ public class ScriptLoader {
     @Override
     public String toString() {
         return "[" + String.join(" | ", names) + "]";
+    }
+    
+    
+    public enum LoaderStage {
+        NOT_LOADED, LOADING, LOADED_SUCCESSFUL, ERROR, UNKNOWN
     }
     
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoaderLoadingEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoaderLoadingEvent.java
@@ -1,0 +1,57 @@
+package crafttweaker.runtime.events;
+
+import crafttweaker.api.network.NetworkSide;
+import crafttweaker.runtime.ScriptLoader;
+
+public class CrTLoaderLoadingEvent {
+    
+    private final ScriptLoader loader;
+    private final NetworkSide networkSide;
+    private final boolean isSyntaxCommand;
+    
+    public CrTLoaderLoadingEvent(ScriptLoader loader, NetworkSide networkSide, boolean isSyntaxCommand) {
+        this.loader = loader;
+        this.networkSide = networkSide;
+        this.isSyntaxCommand = isSyntaxCommand;
+    }
+    
+    public ScriptLoader getLoader() {
+        return loader;
+    }
+    
+    public NetworkSide getNetworkSide() {
+        return networkSide;
+    }
+    
+    public boolean isSyntaxCommand() {
+        return isSyntaxCommand;
+    }
+    
+    public static class Started extends CrTLoaderLoadingEvent {
+        
+        public Started(ScriptLoader loader, NetworkSide networkSide, boolean isSyntaxCommand) {
+            super(loader, networkSide, isSyntaxCommand);
+        }
+    }
+    
+    public static class Finished extends CrTLoaderLoadingEvent {
+        
+        public Finished(ScriptLoader loader, NetworkSide networkSide, boolean isSyntaxCommand) {
+            super(loader, networkSide, isSyntaxCommand);
+        }
+    }
+    
+    public static class Aborted extends CrTLoaderLoadingEvent {
+        
+        private final String message;
+        
+        public Aborted(ScriptLoader loader, NetworkSide networkSide, boolean isSyntaxCommand, String message) {
+            super(loader, networkSide, isSyntaxCommand);
+            this.message = message;
+        }
+        
+        public String getMessage() {
+            return message;
+        }
+    }
+}

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingScriptEventPost.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingScriptEventPost.java
@@ -9,4 +9,9 @@ public class CrTLoadingScriptEventPost extends CrTScriptLoadingEvent.Post {
     public CrTLoadingScriptEventPost(String fileName) {
         super(fileName);
     }
+    
+    @Override
+    public String getFileName() {
+        return super.getFileName();
+    }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingScriptEventPost.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingScriptEventPost.java
@@ -1,14 +1,12 @@
 package crafttweaker.runtime.events;
 
-public class CrTLoadingScriptEventPost {
-    
-    private String fileName;
+/**
+ * Deprecated, use the newly added super class
+ */
+@Deprecated
+public class CrTLoadingScriptEventPost extends CrTScriptLoadingEvent.Post {
     
     public CrTLoadingScriptEventPost(String fileName) {
-        this.fileName = fileName;
-    }
-    
-    public String getFileName() {
-        return fileName;
+        super(fileName);
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingScriptEventPre.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingScriptEventPre.java
@@ -1,14 +1,13 @@
 package crafttweaker.runtime.events;
 
-public class CrTLoadingScriptEventPre {
-    
-    private String fileName;
+
+/**
+ * Deprecated, use the newly added super class
+ */
+@Deprecated
+public class CrTLoadingScriptEventPre extends CrTScriptLoadingEvent.Pre {
     
     public CrTLoadingScriptEventPre(String fileName) {
-        this.fileName = fileName;
-    }
-    
-    public String getFileName() {
-        return fileName;
+        super(fileName);
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingScriptEventPre.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingScriptEventPre.java
@@ -10,4 +10,9 @@ public class CrTLoadingScriptEventPre extends CrTScriptLoadingEvent.Pre {
     public CrTLoadingScriptEventPre(String fileName) {
         super(fileName);
     }
+    
+    @Override
+    public String getFileName() {
+        return super.getFileName();
+    }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingStartedEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingStartedEvent.java
@@ -12,7 +12,7 @@ public class CrTLoadingStartedEvent extends CrTLoaderLoadingEvent.Started {
     
     @Deprecated
     public CrTLoadingStartedEvent(String loaderName, boolean isSyntaxCommand, NetworkSide networkSide) {
-        super(CraftTweakerAPI.tweaker.getOrCreate(loaderName), networkSide, isSyntaxCommand);
+        super(CraftTweakerAPI.tweaker.getOrCreateLoader(loaderName), networkSide, isSyntaxCommand);
     }
     
     public CrTLoadingStartedEvent(ScriptLoader loader, NetworkSide networkSide, boolean isSyntaxCommand) {

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingStartedEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingStartedEvent.java
@@ -15,7 +15,7 @@ public class CrTLoadingStartedEvent extends CrTLoaderLoadingEvent.Started {
         super(CraftTweakerAPI.tweaker.getOrCreateLoader(loaderName), networkSide, isSyntaxCommand);
     }
     
-    public CrTLoadingStartedEvent(ScriptLoader loader, NetworkSide networkSide, boolean isSyntaxCommand) {
+    public CrTLoadingStartedEvent(ScriptLoader loader, boolean isSyntaxCommand, NetworkSide networkSide) {
         super(loader, networkSide, isSyntaxCommand);
     }
     

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingStartedEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingStartedEvent.java
@@ -1,27 +1,25 @@
 package crafttweaker.runtime.events;
 
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.network.NetworkSide;
+import crafttweaker.runtime.ScriptLoader;
 
-public class CrTLoadingStartedEvent {
-    private String loaderName;
-    private boolean isSyntaxCommand;
-    private NetworkSide networkSide;
+/**
+ * Deprecated, use the newly added super class
+ */
+@Deprecated
+public class CrTLoadingStartedEvent extends CrTLoaderLoadingEvent.Started {
     
+    @Deprecated
     public CrTLoadingStartedEvent(String loaderName, boolean isSyntaxCommand, NetworkSide networkSide) {
-        this.loaderName = loaderName;
-        this.isSyntaxCommand = isSyntaxCommand;
-        this.networkSide = networkSide;
+        super(CraftTweakerAPI.tweaker.addLoader(loaderName), networkSide, isSyntaxCommand);
+    }
+    
+    public CrTLoadingStartedEvent(ScriptLoader loader, NetworkSide networkSide, boolean isSyntaxCommand) {
+        super(loader, networkSide, isSyntaxCommand);
     }
     
     public String getLoaderName() {
-        return loaderName;
-    }
-    
-    public boolean isSyntaxCommand() {
-        return isSyntaxCommand;
-    }
-    
-    public NetworkSide getNetworkSide() {
-        return networkSide;
+        return getLoader().getNames().iterator().next();
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingStartedEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTLoadingStartedEvent.java
@@ -12,7 +12,7 @@ public class CrTLoadingStartedEvent extends CrTLoaderLoadingEvent.Started {
     
     @Deprecated
     public CrTLoadingStartedEvent(String loaderName, boolean isSyntaxCommand, NetworkSide networkSide) {
-        super(CraftTweakerAPI.tweaker.addLoader(loaderName), networkSide, isSyntaxCommand);
+        super(CraftTweakerAPI.tweaker.getOrCreate(loaderName), networkSide, isSyntaxCommand);
     }
     
     public CrTLoadingStartedEvent(ScriptLoader loader, NetworkSide networkSide, boolean isSyntaxCommand) {
@@ -20,6 +20,21 @@ public class CrTLoadingStartedEvent extends CrTLoaderLoadingEvent.Started {
     }
     
     public String getLoaderName() {
-        return getLoader().getNames().iterator().next();
+        return getLoader().getMainName();
+    }
+    
+    @Override
+    public ScriptLoader getLoader() {
+        return super.getLoader();
+    }
+    
+    @Override
+    public NetworkSide getNetworkSide() {
+        return super.getNetworkSide();
+    }
+    
+    @Override
+    public boolean isSyntaxCommand() {
+        return super.isSyntaxCommand();
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTScriptLoadingEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/runtime/events/CrTScriptLoadingEvent.java
@@ -1,0 +1,29 @@
+package crafttweaker.runtime.events;
+
+public class CrTScriptLoadingEvent {
+    
+    private final String fileName;
+    
+    public CrTScriptLoadingEvent(String fileName) {
+        this.fileName = fileName;
+    }
+    
+    public String getFileName() {
+        return fileName;
+    }
+    
+    
+    public static class Pre extends CrTScriptLoadingEvent {
+        
+        public Pre(String fileName) {
+            super(fileName);
+        }
+    }
+    
+    public static class Post extends CrTScriptLoadingEvent {
+        
+        public Post(String fileName) {
+            super(fileName);
+        }
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
@@ -22,7 +22,6 @@ import crafttweaker.mc1120.util.CraftTweakerPlatformUtils;
 import crafttweaker.mc1120.vanilla.MCVanilla;
 import crafttweaker.runtime.*;
 import crafttweaker.runtime.providers.*;
-import crafttweaker.socket.CrTSocketHandler;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.fml.common.*;
 import net.minecraftforge.fml.common.Mod.EventHandler;
@@ -115,7 +114,7 @@ public class CraftTweaker {
         IScriptProvider cascaded = new ScriptProviderCascade(scriptsGlobal);
         CrafttweakerImplementationAPI.setScriptProvider(cascaded);
     
-        CraftTweakerAPI.tweaker.addLoader("preinit").setMainName("preinit");
+        CraftTweakerAPI.tweaker.getOrCreateLoader("preinit").setMainName("preinit");
         CraftTweakerAPI.tweaker.loadScript(false, "preinit");
     }
     

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
@@ -20,7 +20,7 @@ import crafttweaker.mc1120.recipes.MCRecipeManager;
 import crafttweaker.mc1120.server.MCServer;
 import crafttweaker.mc1120.util.CraftTweakerPlatformUtils;
 import crafttweaker.mc1120.vanilla.MCVanilla;
-import crafttweaker.runtime.IScriptProvider;
+import crafttweaker.runtime.*;
 import crafttweaker.runtime.providers.*;
 import crafttweaker.socket.CrTSocketHandler;
 import net.minecraft.server.MinecraftServer;
@@ -114,8 +114,8 @@ public class CraftTweaker {
         
         IScriptProvider cascaded = new ScriptProviderCascade(scriptsGlobal);
         CrafttweakerImplementationAPI.setScriptProvider(cascaded);
-        
-        CraftTweakerAPI.tweaker.addLoader("preinit");
+    
+        CraftTweakerAPI.tweaker.addLoader("preinit").setMainName("preinit");
         CraftTweakerAPI.tweaker.loadScript(false, "preinit");
     }
     

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
@@ -114,6 +114,9 @@ public class CraftTweaker {
         
         IScriptProvider cascaded = new ScriptProviderCascade(scriptsGlobal);
         CrafttweakerImplementationAPI.setScriptProvider(cascaded);
+        
+        CraftTweakerAPI.tweaker.addLoader("preinit");
+        CraftTweakerAPI.tweaker.loadScript(false, "preinit");
     }
     
     @EventHandler

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/HelpCommand.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/HelpCommand.java
@@ -90,7 +90,6 @@ public class HelpCommand extends CraftTweakerCommand{
             for(ITextComponent iTextComponent : entry.getDescription()) {
                 int width = (iTextComponent.getUnformattedText().length() / windowWidth) + 1;
                 currentEntry += width;
-                System.out.println( "["+ pages.size() + "]" + iTextComponent.getUnformattedText() + " : " + width);
             }
             
             currentCount += currentEntry;

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/NamesCommand.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/NamesCommand.java
@@ -29,7 +29,7 @@ public class NamesCommand extends CraftTweakerCommand {
     
     @Override
     protected void init() {
-        setDescription(getClickableCommandText("\u00A72/ct names", "/ct names", true), getNormalMessage(" \u00A73Outputs a list of all item names in the game to the CraftTweaker log"), getClickableCommandText(" \u00A7a/ct names desc", "/ct names desc", true), getNormalMessage("  \u00A7bAdds the Display name of the Item to the output"));
+        setDescription(getClickableCommandText("\u00A72/ct names", "/ct names", true), getNormalMessage(" \u00A73Outputs a list of all item names in the game to the CraftTweaker log"), getClickableCommandText(" \u00A7a/ct names display unloc maxstack maxuse maxdamage rarity repaircost damageable repairable creativetabs", "/ct names display unloc maxstack maxuse maxdamage rarity repaircost damageable repairable creativetabs", true), getNormalMessage("  \u00A7bAdds all possible information to the output."));
         
         subCommands = new ArrayList<>(2);
         for(NameCommandParams para : NameCommandParams.values()) {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/ClientEventHandler.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/ClientEventHandler.java
@@ -8,7 +8,7 @@ import crafttweaker.api.tooltip.IngredientTooltips;
 import crafttweaker.mc1120.formatting.IMCFormattedString;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.GameSettings;
-import net.minecraft.client.util.RecipeBookClient;
+import net.minecraft.client.util.*;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.eventhandler.*;
@@ -43,19 +43,9 @@ public class ClientEventHandler {
         final Minecraft minecraft = Minecraft.getMinecraft();
         if(minecraft.player != null && !alreadyChangedThePlayer) {
             alreadyChangedThePlayer = true;
-            
             RecipeBookClient.rebuildTable();
             minecraft.populateSearchTreeManager();
-            
-            // final SimpleReloadableResourceManager manager = ((SimpleReloadableResourceManager) minecraft.getResourceManager());
-            // manager.notifyReloadListeners();
-            // //for(IResourceManagerReloadListener reloadListener : manager.reloadListeners) {
-            // //    //if(reloadListener instanceof SearchTreeManager)
-            // //        reloadListener.onResourceManagerReload(manager);
-            // //}
-            
-            //FIXME find better solution
-            minecraft.refreshResources();
+            ((SearchTree) minecraft.getSearchTreeManager().get(SearchTreeManager.RECIPES)).recalculate();
             CraftTweakerAPI.logInfo("Fixed the RecipeBook");
         }
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/ClientEventHandler.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/ClientEventHandler.java
@@ -7,7 +7,7 @@ import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.api.tooltip.IngredientTooltips;
 import crafttweaker.mc1120.formatting.IMCFormattedString;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.settings.*;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.client.util.RecipeBookClient;
 import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
@@ -15,6 +15,7 @@ import net.minecraftforge.fml.common.eventhandler.*;
 import net.minecraftforge.fml.relauncher.*;
 
 public class ClientEventHandler {
+    
     private static boolean alreadyChangedThePlayer = false;
     
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -34,14 +35,27 @@ public class ClientEventHandler {
             }
         }
     }
+    
     @SubscribeEvent
     @SideOnly(Side.CLIENT)
-    public void onGuiOpenEvent(GuiOpenEvent ev){
+    public void onGuiOpenEvent(GuiOpenEvent ev) {
         
-        if (Minecraft.getMinecraft().player != null && !alreadyChangedThePlayer){
+        final Minecraft minecraft = Minecraft.getMinecraft();
+        if(minecraft.player != null && !alreadyChangedThePlayer) {
             alreadyChangedThePlayer = true;
             
             RecipeBookClient.rebuildTable();
+            minecraft.populateSearchTreeManager();
+            
+            // final SimpleReloadableResourceManager manager = ((SimpleReloadableResourceManager) minecraft.getResourceManager());
+            // manager.notifyReloadListeners();
+            // //for(IResourceManagerReloadListener reloadListener : manager.reloadListeners) {
+            // //    //if(reloadListener instanceof SearchTreeManager)
+            // //        reloadListener.onResourceManagerReload(manager);
+            // //}
+            
+            //FIXME find better solution
+            minecraft.refreshResources();
             CraftTweakerAPI.logInfo("Fixed the RecipeBook");
         }
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
@@ -15,6 +15,7 @@ import crafttweaker.mc1120.furnace.MCFurnaceManager;
 import crafttweaker.mc1120.item.MCItemStack;
 import crafttweaker.mc1120.oredict.MCOreDictEntry;
 import crafttweaker.mc1120.recipes.*;
+import crafttweaker.runtime.ScriptLoader;
 import net.minecraft.entity.*;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -54,8 +55,9 @@ public class CommonEventHandler {
         BracketHandlerBiomeType.rebuildBiomeTypeRegistry();
         CraftTweakerAPI.logInfo("CraftTweaker: Successfully built item registry");
         MinecraftForge.EVENT_BUS.post(new ScriptRunEvent.Pre());
-        CraftTweakerAPI.tweaker.addLoader("crafttweaker", "recipeEvent");
-        CrafttweakerImplementationAPI.load();
+        final ScriptLoader loader = CraftTweakerAPI.tweaker.getOrCreateLoader("crafttweaker", "recipeEvent");
+        loader.setMainName("crafttweaker");
+        CraftTweakerAPI.tweaker.loadScript(false, loader);
         MinecraftForge.EVENT_BUS.post(new ScriptRunEvent.Post());
         
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
@@ -51,6 +51,7 @@ public class CommonEventHandler {
         
         CraftTweakerAPI.logInfo("CraftTweaker: Successfully built item registry");
         MinecraftForge.EVENT_BUS.post(new ScriptRunEvent.Pre());
+        CraftTweakerAPI.tweaker.addLoader("crafttweaker", "recipeEvent");
         CrafttweakerImplementationAPI.load();
         MinecraftForge.EVENT_BUS.post(new ScriptRunEvent.Post());
         

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/logger/MCLogger.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/logger/MCLogger.java
@@ -12,6 +12,7 @@ public class MCLogger implements ILogger {
     private static final Pattern FORMATTING_CODE_PATTERN = Pattern.compile("(?i)" + String.valueOf('\u00a7') + "[0-9A-FK-OR]");
     private final Writer writer;
     private final PrintWriter printWriter;
+    private boolean isDefaultDisabled = false;
 
     public MCLogger(File output) {
         try {
@@ -82,5 +83,21 @@ public class MCLogger implements ILogger {
      */
     public String stripMessage(String message) {
         return message == null ? null : FORMATTING_CODE_PATTERN.matcher(message).replaceAll("");
+    }
+    
+    @Override
+    public void logDefault(String message) {
+        if(!isLogDisabled())
+            logInfo(message);
+    }
+    
+    @Override
+    public boolean isLogDisabled() {
+        return isDefaultDisabled;
+    }
+    
+    @Override
+    public void setLogDisabled(boolean logDisabled) {
+        this.isDefaultDisabled = logDisabled;
     }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
@@ -103,7 +103,10 @@ public class MCOreDictEntry implements IOreDictEntry {
     
     @Override
     public void add(IItemStack... items) {
+        final List<IItemStack> removedContents = REMOVED_CONTENTS.get(id);
         for(IItemStack item : items) {
+            if(removedContents != null)
+                removedContents.removeIf(removedItem -> removedItem.matches(item));
             ItemStack stack = getItemStack(item);
             if(!stack.isEmpty()) {
                 CraftTweakerAPI.apply(new ActionOreDictAddItem(id, stack));

--- a/CraftTweaker2-MC1120-Main/src/test/java/TestLoaders.java
+++ b/CraftTweaker2-MC1120-Main/src/test/java/TestLoaders.java
@@ -1,16 +1,76 @@
-import crafttweaker.CraftTweakerAPI;
+import crafttweaker.*;
+import crafttweaker.api.player.IPlayer;
+import crafttweaker.runtime.*;
+
+import java.util.Collections;
 
 public class TestLoaders {
     
     public static void main(String[] args) {
+        
+        CraftTweakerAPI.tweaker.setScriptProvider(Collections.EMPTY_LIST::iterator);
+        CrafttweakerImplementationAPI.logger.addLogger(new SoutLogger());
+        
+        
         CraftTweakerAPI.tweaker.addLoader("test1");
         CraftTweakerAPI.tweaker.addLoader("test2");
         CraftTweakerAPI.tweaker.addLoader("test1", "test2");
-        CraftTweakerAPI.tweaker.addLoader("test3", "test4");
+        CraftTweakerAPI.tweaker.addLoader("test3", "test4").setMainName("test5");
         CraftTweakerAPI.tweaker.addLoader("test1", "test3");
         
-    
         CraftTweakerAPI.tweaker.loadScript(false, "test1");
+        
+        CraftTweakerAPI.tweaker.addLoader("test5", "test6", "test7", "test8");
         CraftTweakerAPI.tweaker.loadScript(false, "test4");
+        
+    }
+    
+    
+    private static class SoutLogger implements ILogger {
+        
+        @Override
+        public void logCommand(String message) {
+            System.out.println("[Command] " + message);
+        }
+        
+        @Override
+        public void logInfo(String message) {
+            System.out.println("[INFO] " + message);
+        }
+        
+        @Override
+        public void logWarning(String message) {
+            System.out.println("[WARNING]" + message);
+        }
+        
+        @Override
+        public void logError(String message) {
+            System.out.println("[ERROR]" + message);
+        }
+        
+        @Override
+        public void logError(String message, Throwable exception) {
+            logError(message);
+        }
+        
+        @Override
+        public void logPlayer(IPlayer player) {
+            System.out.println("[PLAYER] " + player.getName());
+        }
+        
+        @Override
+        public void logDefault(String message) {
+            System.out.println("[DEFAULT]" + message);
+        }
+        
+        @Override
+        public boolean isLogDisabled() {
+            return false;
+        }
+        
+        @Override
+        public void setLogDisabled(boolean logDisabled) {
+            //No-OP
+        }
     }
 }

--- a/CraftTweaker2-MC1120-Main/src/test/java/TestLoaders.java
+++ b/CraftTweaker2-MC1120-Main/src/test/java/TestLoaders.java
@@ -1,0 +1,16 @@
+import crafttweaker.CraftTweakerAPI;
+
+public class TestLoaders {
+    
+    public static void main(String[] args) {
+        CraftTweakerAPI.tweaker.addLoader("test1");
+        CraftTweakerAPI.tweaker.addLoader("test2");
+        CraftTweakerAPI.tweaker.addLoader("test1", "test2");
+        CraftTweakerAPI.tweaker.addLoader("test3", "test4");
+        CraftTweakerAPI.tweaker.addLoader("test1", "test3");
+        
+    
+        CraftTweakerAPI.tweaker.loadScript(false, "test1");
+        CraftTweakerAPI.tweaker.loadScript(false, "test4");
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/test/java/TestLoaders.java
+++ b/CraftTweaker2-MC1120-Main/src/test/java/TestLoaders.java
@@ -8,21 +8,27 @@ public class TestLoaders {
     
     public static void main(String[] args) {
         
-        CraftTweakerAPI.tweaker.setScriptProvider(Collections.EMPTY_LIST::iterator);
+        CraftTweakerAPI.tweaker.setScriptProvider(Collections::emptyIterator);
         CrafttweakerImplementationAPI.logger.addLogger(new SoutLogger());
         
         
-        CraftTweakerAPI.tweaker.addLoader("test1");
-        CraftTweakerAPI.tweaker.addLoader("test2");
-        CraftTweakerAPI.tweaker.addLoader("test1", "test2");
-        CraftTweakerAPI.tweaker.addLoader("test3", "test4").setMainName("test5");
-        CraftTweakerAPI.tweaker.addLoader("test1", "test3");
+        CraftTweakerAPI.tweaker.getOrCreateLoader("test1");
+        CraftTweakerAPI.tweaker.getOrCreateLoader("test2");
+        CraftTweakerAPI.tweaker.getOrCreateLoader("test1", "test2");
+        CraftTweakerAPI.tweaker.getOrCreateLoader("test3", "test4").setMainName("test5");
+        CraftTweakerAPI.tweaker.getOrCreateLoader("test1", "test3");
+    
+        CraftTweakerAPI.logInfo("Stage: " + CraftTweakerAPI.tweaker.getOrCreateLoader("test2").getLoaderStage());
         
         CraftTweakerAPI.tweaker.loadScript(false, "test1");
+    
+        CraftTweakerAPI.logInfo("Stage: " + CraftTweakerAPI.tweaker.getOrCreateLoader("test2").getLoaderStage());
         
-        CraftTweakerAPI.tweaker.addLoader("test5", "test6", "test7", "test8");
+        CraftTweakerAPI.tweaker.getOrCreateLoader("test5", "test6", "test7", "test8");
         CraftTweakerAPI.tweaker.loadScript(false, "test4");
         
+        
+        CraftTweakerAPI.logInfo("Stage: " + CraftTweakerAPI.tweaker.getOrCreateLoader("test2").getLoaderStage());
     }
     
     


### PR DESCRIPTION
Not yet complete, simply adding it here already so that I have a reason not to forget it anytime soon.

Also closes #561  (blood fixed that during a shared code session)
Also closes #487  (though we already closed it for not being fixable :stuck_out_tongue: )


In general, users will be able to use `addLoader(String... names)` to create a loader object with the given names/aliases. If any of those aliases is already present on an already existing preloader, all names will be added to that preloader as aliases.
If then any mod calls any of the aliases to be loaded, CrT will check against of the names instead, and also ensures that each loader will be executed only once by keeping an instance bool on the loader objects.

For mods that require to know the result of the loader execution, even if it was executed by another mod, the loader Objects have a status enumeration that will tell if the loader is not yet loaded, has errored or loaded fine.