### PR TITLE
Blockstate handling and matching

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
@@ -31,7 +31,7 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
 
     @Override
     public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
-        CraftTweakerAPI.logWarning("Cannot change allowed values for a compound blockstate matcher")
+        CraftTweakerAPI.logWarning("Cannot change allowed values for a compound blockstate matcher");
         return this;
     }
 

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
@@ -1,5 +1,6 @@
 package crafttweaker.api.block;
 
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.util.ArrayUtil;
 
 import java.util.ArrayList;
@@ -30,7 +31,8 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
 
     @Override
     public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
-        return null;
+        CraftTweakerAPI.logWarning("Cannot change allowed values for a compound blockstate matcher")
+        return this;
     }
 
     @Override
@@ -43,7 +45,9 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
         Collection<IBlockState> matchingStates = new ArrayList<>();
         for (IBlockStateMatcher matcher : elements) {
             Collection<IBlockState> states = matcher.getMatchingBlockStates();
-            if (states == null) continue;
+            if (states == null) {
+                continue;
+            }
             matchingStates.addAll(states);
         }
         return matchingStates;

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
@@ -1,0 +1,36 @@
+package crafttweaker.api.block;
+
+import crafttweaker.util.ArrayUtil;
+
+public class BlockStateMatcherOr implements IBlockStateMatcher {
+
+    private final IBlockStateMatcher[] elements;
+
+    public BlockStateMatcherOr(IBlockStateMatcher[] elements) {
+        this.elements = elements;
+    }
+
+    public BlockStateMatcherOr(IBlockStateMatcher a, IBlockStateMatcher b) {
+        this.elements = new IBlockStateMatcher[]{a, b};
+    }
+
+    @Override
+    public boolean matches(IBlockState blockState) {
+        for (IBlockStateMatcher matcher : elements) {
+            if (matcher.matches(blockState)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
+        return null;
+    }
+
+    @Override
+    public IBlockStateMatcher or(IBlockStateMatcher matcher) {
+        return new BlockStateMatcherOr(ArrayUtil.append(elements, matcher));
+    }
+}

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
@@ -2,6 +2,10 @@ package crafttweaker.api.block;
 
 import crafttweaker.util.ArrayUtil;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 public class BlockStateMatcherOr implements IBlockStateMatcher {
 
     private final IBlockStateMatcher[] elements;
@@ -32,5 +36,16 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
     @Override
     public IBlockStateMatcher or(IBlockStateMatcher matcher) {
         return new BlockStateMatcherOr(ArrayUtil.append(elements, matcher));
+    }
+
+    @Override
+    public Collection<IBlockState> getMatchingBlockStates() {
+        Collection<IBlockState> matchingStates = new ArrayList<>();
+        for (IBlockStateMatcher matcher : elements) {
+            Collection<IBlockState> states = matcher.getMatchingBlockStates();
+            if (states == null) continue;
+            matchingStates.addAll(states);
+        }
+        return matchingStates;
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockState.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockState.java
@@ -6,7 +6,7 @@ import stanhebben.zenscript.annotations.*;
 
 @ZenClass("crafttweaker.block.IBlockState")
 @ZenRegister
-public interface IBlockState extends IBlockProperties {
+public interface IBlockState extends IBlockProperties, IBlockStateMatcher {
     
     @ZenMethod
     @ZenGetter("block")
@@ -22,4 +22,7 @@ public interface IBlockState extends IBlockProperties {
     @ZenMethod
     @ZenOperator(OperatorType.COMPARE)
     int compare(IBlockState other);
+
+    @ZenMethod
+    IBlockState withProperty(String name, String value);
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
@@ -3,6 +3,9 @@ package crafttweaker.api.block;
         import crafttweaker.annotations.ZenRegister;
         import stanhebben.zenscript.annotations.*;
 
+        import java.util.Collection;
+        import java.util.List;
+
 @ZenClass("crafttweaker.block.IBlockStateMatcher")
 @ZenRegister
 public interface IBlockStateMatcher {
@@ -14,4 +17,6 @@ public interface IBlockStateMatcher {
 
     @ZenOperator(OperatorType.OR)
     IBlockStateMatcher or(IBlockStateMatcher matcher);
+
+    Collection<IBlockState> getMatchingBlockStates();
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
@@ -4,7 +4,6 @@ import crafttweaker.annotations.ZenRegister;
 import stanhebben.zenscript.annotations.*;
 
 import java.util.Collection;
-import java.util.List;
 
 @ZenClass("crafttweaker.block.IBlockStateMatcher")
 @ZenRegister

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
@@ -1,10 +1,10 @@
 package crafttweaker.api.block;
 
-        import crafttweaker.annotations.ZenRegister;
-        import stanhebben.zenscript.annotations.*;
+import crafttweaker.annotations.ZenRegister;
+import stanhebben.zenscript.annotations.*;
 
-        import java.util.Collection;
-        import java.util.List;
+import java.util.Collection;
+import java.util.List;
 
 @ZenClass("crafttweaker.block.IBlockStateMatcher")
 @ZenRegister
@@ -18,5 +18,6 @@ public interface IBlockStateMatcher {
     @ZenOperator(OperatorType.OR)
     IBlockStateMatcher or(IBlockStateMatcher matcher);
 
+    @ZenMethod
     Collection<IBlockState> getMatchingBlockStates();
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
@@ -1,7 +1,7 @@
 package crafttweaker.api.block;
 
-import crafttweaker.annotations.ZenRegister;
-import stanhebben.zenscript.annotations.*;
+        import crafttweaker.annotations.ZenRegister;
+        import stanhebben.zenscript.annotations.*;
 
 @ZenClass("crafttweaker.block.IBlockStateMatcher")
 @ZenRegister

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
@@ -1,0 +1,17 @@
+package crafttweaker.api.block;
+
+import crafttweaker.annotations.ZenRegister;
+import stanhebben.zenscript.annotations.*;
+
+@ZenClass("crafttweaker.block.IBlockStateMatcher")
+@ZenRegister
+public interface IBlockStateMatcher {
+    @ZenMethod
+    boolean matches(IBlockState blockState);
+
+    @ZenMethod
+    IBlockStateMatcher allowValuesForProperty(String name, String... values);
+
+    @ZenOperator(OperatorType.OR)
+    IBlockStateMatcher or(IBlockStateMatcher matcher);
+}

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/world/IWorld.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/world/IWorld.java
@@ -2,6 +2,7 @@ package crafttweaker.api.world;
 
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.block.*;
+import crafttweaker.api.data.IData;
 import crafttweaker.api.entity.IEntity;
 import crafttweaker.api.util.Position3f;
 import stanhebben.zenscript.annotations.*;
@@ -70,6 +71,9 @@ public interface IWorld extends IBlockAccess {
     
     @ZenMethod
     boolean setBlockState(IBlockState state, IBlockPos pos);
+
+    @ZenMethod
+    boolean setBlockState(IBlockState state, IData tileEntityData, IBlockPos pos);
     
     @ZenGetter("provider")
     @ZenMethod

--- a/CraftTweaker2-API/src/main/java/crafttweaker/util/ArrayUtil.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/util/ArrayUtil.java
@@ -1,6 +1,7 @@
 package crafttweaker.util;
 
 import crafttweaker.api.block.IBlockPattern;
+import crafttweaker.api.block.IBlockStateMatcher;
 import crafttweaker.api.item.*;
 
 import java.util.Arrays;
@@ -34,6 +35,12 @@ public class ArrayUtil {
     
     public static IBlockPattern[] append(IBlockPattern[] values, IBlockPattern value) {
         IBlockPattern[] result = Arrays.copyOf(values, values.length + 1);
+        result[values.length] = value;
+        return result;
+    }
+
+    public static IBlockStateMatcher[] append(IBlockStateMatcher[] values, IBlockStateMatcher value) {
+        IBlockStateMatcher[] result = Arrays.copyOf(values, values.length + 1);
         result[values.length] = value;
         return result;
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -62,7 +62,7 @@ public class BlockStateMatcher implements IBlockStateMatcher {
             newProps.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
         }
         newProps.put(name, ImmutableList.copyOf(values));
-        return new BlockStateMatcher(this.blockState, newProps);
+        return new BlockStateMatcher(blockState, newProps);
     }
 
     @Override
@@ -76,6 +76,7 @@ public class BlockStateMatcher implements IBlockStateMatcher {
         return state.getBlock().getBlockState().getValidStates()
                 .stream()
                 .map(MCBlockState::new)
+                .filter(this::matches)
                 .collect(Collectors.toList());
     }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -2,14 +2,18 @@ package crafttweaker.mc1120.block;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.block.*;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
+@ZenClass("crafttweaker.mc1120.block.BlockStateMatcher")
+@ZenRegister
 public class BlockStateMatcher implements IBlockStateMatcher {
 
     private final crafttweaker.api.block.IBlockState blockState;
@@ -22,6 +26,16 @@ public class BlockStateMatcher implements IBlockStateMatcher {
 
     public BlockStateMatcher(crafttweaker.api.block.IBlockState blockState) {
         this(blockState, ImmutableMap.of());
+    }
+
+    @ZenMethod
+    public static IBlockStateMatcher create(crafttweaker.api.block.IBlockState... blockStates) {
+        if (blockStates == null || blockStates.length == 0) return null;
+        if (blockStates.length == 1) {
+            return new BlockStateMatcher(blockStates[0]);
+        } else {
+            return new BlockStateMatcherOr(Arrays.copyOf(blockStates, blockStates.length));
+        }
     }
 
     @Override
@@ -54,5 +68,14 @@ public class BlockStateMatcher implements IBlockStateMatcher {
     @Override
     public IBlockStateMatcher or(IBlockStateMatcher matcher) {
         return new BlockStateMatcherOr(this, matcher);
+    }
+
+    @Override
+    public Collection<crafttweaker.api.block.IBlockState> getMatchingBlockStates() {
+        IBlockState state = ((IBlockState) blockState.getInternal());
+        return state.getBlock().getBlockState().getValidStates()
+                .stream()
+                .map(MCBlockState::new)
+                .collect(Collectors.toList());
     }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -2,13 +2,9 @@ package crafttweaker.mc1120.block;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import crafttweaker.CraftTweakerAPI;
-import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.block.*;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
-import stanhebben.zenscript.annotations.ZenClass;
-import stanhebben.zenscript.annotations.ZenMethod;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -44,13 +40,12 @@ public class BlockStateMatcher implements IBlockStateMatcher {
     }
 
     @Override
-    public boolean matches(crafttweaker.api.block.IBlockState toMatch) {
-        if (toMatch == null) {
+    public boolean matches(crafttweaker.api.block.IBlockState stateToMatch) {
+        if (stateToMatch == null) {
             return false;
         }
-        // If the internal Blocks are equal, there is a possible match
-        if (((IBlockState) this.blockState.getInternal()).getBlock().equals(((IBlockState) toMatch.getInternal()).getBlock())) {
-            for (Map.Entry<IProperty<?>, Comparable<?>> entry : ((IBlockState) toMatch.getInternal()).getProperties().entrySet()) {
+        if (((IBlockState) this.blockState.getInternal()).getBlock().equals(((IBlockState) stateToMatch.getInternal()).getBlock())) {
+            for (Map.Entry<IProperty<?>, Comparable<?>> entry : ((IBlockState) stateToMatch.getInternal()).getProperties().entrySet()) {
                 List<String> allowed = allowedProperties.get(entry.getKey().getName());
                 if (allowed != null && !(allowed.contains(entry.getValue().toString()) || allowed.contains("*"))) {
                     return false;
@@ -63,15 +58,11 @@ public class BlockStateMatcher implements IBlockStateMatcher {
 
     @Override
     public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
-        // Create a new map
         Map<String, List<String>> newProps = new HashMap<>();
-        // Copy over current values
         for (Map.Entry<String, List<String>> entry : allowedProperties.entrySet()) {
             newProps.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
         }
-        // Put the specified allowed values into the map
         newProps.put(name, ImmutableList.copyOf(values));
-        // Wham, bam, thank-you-ma'am
         return new BlockStateMatcher(blockState, newProps);
     }
 
@@ -83,10 +74,10 @@ public class BlockStateMatcher implements IBlockStateMatcher {
     @Override
     public Collection<crafttweaker.api.block.IBlockState> getMatchingBlockStates() {
         IBlockState state = ((IBlockState) blockState.getInternal());
-        return state.getBlock().getBlockState().getValidStates() // get list of valid states
+        return state.getBlock().getBlockState().getValidStates()
                 .stream()
-                .map(MCBlockState::new)     // convert to crafttweaker IBlockStates
-                .filter(this::matches)      // filter for matching states
-                .collect(Collectors.toList());  // collect and return
+                .map(MCBlockState::new)
+                .filter(this::matches)
+                .collect(Collectors.toList());
     }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -33,7 +33,7 @@ public class BlockStateMatcher implements IBlockStateMatcher {
         }
         for (Object o : blockStates) {
             if (o == null) {
-                throw new IllegalArgumentException("Cannot create matcher for null blockstate")
+                throw new IllegalArgumentException("Cannot create matcher for null blockstate");
             }
         }
         if (blockStates.length == 1) {
@@ -45,7 +45,7 @@ public class BlockStateMatcher implements IBlockStateMatcher {
 
     @Override
     public boolean matches(crafttweaker.api.block.IBlockState toMatch) {
-        if (other == null) {
+        if (toMatch == null) {
             return false;
         }
         // If internal states are equal, they must match
@@ -56,7 +56,7 @@ public class BlockStateMatcher implements IBlockStateMatcher {
             // Iterate over the properties in `toMatch`
             for (Map.Entry<IProperty<?>, Comparable<?>> entry : ((IBlockState) toMatch.getInternal()).getProperties().entrySet()) {
                 // If this matcher has values specified for this property name, and the value is not in the list of allowed values
-                List<String> allowed = allowedProperties.get(entry.getKey().getName())
+                List<String> allowed = allowedProperties.get(entry.getKey().getName());
                 if (allowed != null && !(allowed.contains(entry.getValue().toString()) || allowed.contains("*"))) {
                     // No dice.
                     return false;

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -1,0 +1,58 @@
+package crafttweaker.mc1120.block;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import crafttweaker.api.block.*;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.IBlockState;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BlockStateMatcher implements IBlockStateMatcher {
+
+    private final crafttweaker.api.block.IBlockState blockState;
+    private final Map<String, List<String>> allowedProperties;
+
+    public BlockStateMatcher(crafttweaker.api.block.IBlockState blockState, Map<String, List<String>> allowedProperties) {
+        this.blockState = blockState;
+        this.allowedProperties = ImmutableMap.copyOf(allowedProperties);
+    }
+
+    public BlockStateMatcher(crafttweaker.api.block.IBlockState blockState) {
+        this(blockState, ImmutableMap.of());
+    }
+
+    @Override
+    public boolean matches(crafttweaker.api.block.IBlockState other) {
+        if (this.blockState.getInternal().equals(other.getInternal())) {
+            return true;
+        } else if (((IBlockState) this.blockState.getInternal()).getBlock().equals(((IBlockState) other.getInternal()).getBlock())) {
+            for (Map.Entry<IProperty<?>, Comparable<?>> entry : ((IBlockState)other.getInternal()).getProperties().entrySet()) {
+                if (allowedProperties.containsKey(entry.getKey().getName())) {
+                    if (!allowedProperties.get(entry.getKey().getName()).contains(entry.getValue().toString())) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
+        Map<String, List<String>> newProps = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry : allowedProperties.entrySet()) {
+            newProps.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
+        }
+        newProps.put(name, ImmutableList.copyOf(values));
+        return new BlockStateMatcher(this.blockState, newProps);
+    }
+
+    @Override
+    public IBlockStateMatcher or(IBlockStateMatcher matcher) {
+        return new BlockStateMatcherOr(this, matcher);
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -48,21 +48,14 @@ public class BlockStateMatcher implements IBlockStateMatcher {
         if (toMatch == null) {
             return false;
         }
-        // If internal states are equal, they must match
-        if (this.blockState.getInternal().equals(toMatch.getInternal())) {
-            return true;
-        // Otherwise if the internal Blocks are equal, there is a possible match
-        } else if (((IBlockState) this.blockState.getInternal()).getBlock().equals(((IBlockState) toMatch.getInternal()).getBlock())) {
-            // Iterate over the properties in `toMatch`
+        // If the internal Blocks are equal, there is a possible match
+        if (((IBlockState) this.blockState.getInternal()).getBlock().equals(((IBlockState) toMatch.getInternal()).getBlock())) {
             for (Map.Entry<IProperty<?>, Comparable<?>> entry : ((IBlockState) toMatch.getInternal()).getProperties().entrySet()) {
-                // If this matcher has values specified for this property name, and the value is not in the list of allowed values
                 List<String> allowed = allowedProperties.get(entry.getKey().getName());
                 if (allowed != null && !(allowed.contains(entry.getValue().toString()) || allowed.contains("*"))) {
-                    // No dice.
                     return false;
                 }
             }
-            // Every property was either not specified, wildcarded, or matched an allowed value
             return true;
         }
         return false;

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -12,9 +12,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistry;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class MCBlockState extends MCBlockProperties implements crafttweaker.api.block.IBlockState {
     
@@ -86,5 +84,10 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     @Override
     public IBlockStateMatcher or(IBlockStateMatcher matcher) {
         return new BlockStateMatcherOr(this, matcher);
+    }
+
+    @Override
+    public Collection<crafttweaker.api.block.IBlockState> getMatchingBlockStates() {
+        return ImmutableList.of(this);
     }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -2,6 +2,7 @@ package crafttweaker.mc1120.block;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.block.*;
 import crafttweaker.api.world.*;
 import net.minecraft.block.Block;
@@ -60,13 +61,18 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     @Override
     public crafttweaker.api.block.IBlockState withProperty(String name, String value) {
         IProperty property = blockState.getBlock().getBlockState().getProperty(name);
-        //noinspection unchecked
-        Optional<? extends Comparable> propValue = property.parseValue(value);
-        if (propValue.isPresent()) {
+        if (property == null) {
+            CrafttweakerAPI.logWarning("Invalid property name");
+        } else {
             //noinspection unchecked
-            return new MCBlockState(blockState.withProperty(property, propValue.get()));
+            Optional<? extends Comparable> propValue = property.parseValue(value);
+            if (propValue.isPresent()) {
+                //noinspection unchecked
+                return new MCBlockState(blockState.withProperty(property, propValue.get()));
+            }
+            CrafttweakerAPI.logWarning("Invalid property value");
         }
-        return null;
+        return this;
     }
 
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -1,13 +1,20 @@
 package crafttweaker.mc1120.block;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import crafttweaker.api.block.*;
 import crafttweaker.api.world.*;
 import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.registries.ForgeRegistry;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MCBlockState extends MCBlockProperties implements crafttweaker.api.block.IBlockState {
     
@@ -51,5 +58,33 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
         }
         return result;
     }
-    
+
+    @Override
+    public crafttweaker.api.block.IBlockState withProperty(String name, String value) {
+        IProperty property = blockState.getBlock().getBlockState().getProperty(name);
+        //noinspection unchecked
+        Optional<? extends Comparable> propValue = property.parseValue(value);
+        if (propValue.isPresent()) {
+            //noinspection unchecked
+            return new MCBlockState(blockState.withProperty(property, propValue.get()));
+        }
+        return null;
+    }
+
+    @Override
+    public boolean matches(crafttweaker.api.block.IBlockState other) {
+        return compare(other) == 0;
+    }
+
+    @Override
+    public IBlockStateMatcher allowValuesForProperty(String propertyName, String... propertyValues) {
+        Map<String, List<String>> newProps = new HashMap<>();
+        newProps.put(propertyName, ImmutableList.copyOf(propertyValues));
+        return new BlockStateMatcher(this, newProps);
+    }
+
+    @Override
+    public IBlockStateMatcher or(IBlockStateMatcher matcher) {
+        return new BlockStateMatcherOr(this, matcher);
+    }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -62,7 +62,7 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     public crafttweaker.api.block.IBlockState withProperty(String name, String value) {
         IProperty property = blockState.getBlock().getBlockState().getProperty(name);
         if (property == null) {
-            CrafttweakerAPI.logWarning("Invalid property name");
+            CraftTweakerAPI.logWarning("Invalid property name");
         } else {
             //noinspection unchecked
             Optional<? extends Comparable> propValue = property.parseValue(value);
@@ -70,7 +70,7 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
                 //noinspection unchecked
                 return new MCBlockState(blockState.withProperty(property, propValue.get()));
             }
-            CrafttweakerAPI.logWarning("Invalid property value");
+            CraftTweakerAPI.logWarning("Invalid property value");
         }
         return this;
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/expand/ExpandBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/expand/ExpandBlockState.java
@@ -1,0 +1,17 @@
+package crafttweaker.mc1120.block.expand;
+
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.block.IBlockState;
+import crafttweaker.mc1120.brackets.BracketHandlerBlockState;
+import stanhebben.zenscript.annotations.*;
+
+@ZenExpansion("crafttweaker.block.IBlockState")
+@ZenRegister
+public class ExpandBlockState {
+
+    @ZenMethodStatic
+    public static IBlockState getBlockState(String blockname, String... properties) {
+        return BracketHandlerBlockState.getBlockState(blockname, String.join(":", properties));
+    }
+
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/expand/ExpandBlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/expand/ExpandBlockStateMatcher.java
@@ -1,0 +1,18 @@
+package crafttweaker.mc1120.block.expand;
+
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.block.IBlockState;
+import crafttweaker.api.block.IBlockStateMatcher;
+import crafttweaker.mc1120.block.BlockStateMatcher;
+import stanhebben.zenscript.annotations.*;
+
+@ZenExpansion("crafttweaker.block.IBlockStateMatcher")
+@ZenRegister
+public class ExpandBlockStateMatcher {
+
+    @ZenMethodStatic
+    public static IBlockStateMatcher create(IBlockState... blockStates) {
+        return BlockStateMatcher.create(blockStates);
+    }
+
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brackets/BracketHandlerBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brackets/BracketHandlerBlockState.java
@@ -33,7 +33,7 @@ public class BracketHandlerBlockState implements IBracketHandler {
 
         if (block != null) {
             iBlock = new MCBlockState(block.getDefaultState());
-            if (properties != null) {
+            if (properties != null && properties.length() > 0) {
                 for (String propertyPair : properties.split(",")) {
                     String[] splitPair = propertyPair.split("=");
                     if (splitPair.length != 2)
@@ -57,7 +57,7 @@ public class BracketHandlerBlockState implements IBracketHandler {
         if (split.length > 1) {
             if ("blockstate".equalsIgnoreCase(split[0])) {
                 String blockName;
-                String properties = null;
+                String properties = "";
                 if (split.length > 2) {
                     blockName = split[1] + ":" + split[2];
                     if (split.length > 3) {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brackets/BracketHandlerBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brackets/BracketHandlerBlockState.java
@@ -1,0 +1,90 @@
+package crafttweaker.mc1120.brackets;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.block.IBlockState;
+import crafttweaker.mc1120.block.MCBlockState;
+import crafttweaker.zenscript.IBracketHandler;
+import net.minecraft.block.Block;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import stanhebben.zenscript.compiler.IEnvironmentGlobal;
+import stanhebben.zenscript.expression.ExpressionCallStatic;
+import stanhebben.zenscript.expression.ExpressionString;
+import stanhebben.zenscript.expression.partial.IPartialExpression;
+import stanhebben.zenscript.impl.BracketHandler;
+import stanhebben.zenscript.parser.Token;
+import stanhebben.zenscript.symbols.IZenSymbol;
+import stanhebben.zenscript.type.natives.IJavaMethod;
+import stanhebben.zenscript.util.ZenPosition;
+
+import java.util.List;
+
+@BracketHandler(priority = 100)
+@ZenRegister
+public class BracketHandlerBlockState implements IBracketHandler {
+    private final IJavaMethod method;
+
+    public BracketHandlerBlockState() {
+        method = CraftTweakerAPI.getJavaMethod(BracketHandlerBlockState.class, "getBlockState", String.class, String.class);
+    }
+
+    public static IBlockState getBlockState(String name, String properties) {
+        IBlockState iBlock = null;
+        Block block = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(name));
+
+        if (block != null) {
+            iBlock = new MCBlockState(block.getDefaultState());
+            for (String propertyPair : properties.split(",")) {
+                String[] splitPair = propertyPair.split("=");
+                if (splitPair.length != 2)
+                    return null;
+                iBlock = iBlock.withProperty(splitPair[0], splitPair[1]);
+            }
+        }
+
+        return iBlock;
+    }
+
+    @Override
+    public IZenSymbol resolve(IEnvironmentGlobal environment, List<Token> tokens) {
+        IZenSymbol zenSymbol = null;
+
+        if (tokens.size() > 2) {
+            if ("blockstate".equalsIgnoreCase(tokens.get(0).getValue())) {
+                String blockName;
+                String properties = null;
+                if (tokens.size() >= 5) {
+                    blockName = tokens.get(2).getValue() + ":" + tokens.get(4).getValue();
+                } else {
+                    blockName = tokens.get(2).getValue();
+                }
+                zenSymbol = new BlockStateReferenceSymbol(environment, blockName, properties);
+            }
+        }
+
+        return zenSymbol;
+    }
+
+    @Override
+    public String getRegexMatchingString() {
+        return "blockstate:.*";
+    }
+
+    private class BlockStateReferenceSymbol implements IZenSymbol {
+        private final IEnvironmentGlobal environment;
+        private final String name;
+        private final String properties;
+
+        public BlockStateReferenceSymbol(IEnvironmentGlobal environment, String name, String properties) {
+            this.environment = environment;
+            this.name = name;
+            this.properties = properties;
+        }
+
+        @Override
+        public IPartialExpression instance(ZenPosition position) {
+            return new ExpressionCallStatic(position, environment, method, new ExpressionString(position, name), new ExpressionString(position, properties));
+        }
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brackets/BracketHandlerBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brackets/BracketHandlerBlockState.java
@@ -28,22 +28,26 @@ public class BracketHandlerBlockState implements IBracketHandler {
     }
 
     public static IBlockState getBlockState(String name, String properties) {
-        IBlockState iBlock = null;
+        IBlockState blockState = null;
         Block block = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(name));
 
         if (block != null) {
-            iBlock = new MCBlockState(block.getDefaultState());
+            blockState = new MCBlockState(block.getDefaultState());
             if (properties != null && properties.length() > 0) {
                 for (String propertyPair : properties.split(",")) {
                     String[] splitPair = propertyPair.split("=");
-                    if (splitPair.length != 2)
-                        return null;
-                    iBlock = iBlock.withProperty(splitPair[0], splitPair[1]);
+                    if (splitPair.length != 2) {
+                        CraftTweakerAPI.logWarning("Invalid blockstate property format");
+                        continue;
+                    }
+                    blockState = blockState.withProperty(splitPair[0], splitPair[1]);
                 }
             }
+        } else {
+            CraftTweakerAPI.logWarning("No block found named " + name);
         }
 
-        return iBlock;
+        return blockState;
     }
 
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brackets/BracketHandlerBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brackets/BracketHandlerBlockState.java
@@ -6,6 +6,7 @@ import crafttweaker.api.block.IBlockState;
 import crafttweaker.mc1120.block.MCBlockState;
 import crafttweaker.zenscript.IBracketHandler;
 import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import stanhebben.zenscript.compiler.IEnvironmentGlobal;
@@ -29,7 +30,13 @@ public class BracketHandlerBlockState implements IBracketHandler {
 
     public static IBlockState getBlockState(String name, String properties) {
         IBlockState blockState = null;
+
+        if (!ForgeRegistries.BLOCKS.containsKey(new ResourceLocation(name))) {
+            CraftTweakerAPI.logError("No block found with name '" + name + "'. Air block used instead.");
+        }
+
         Block block = ForgeRegistries.BLOCKS.getValue(new ResourceLocation(name));
+
 
         if (block != null) {
             blockState = new MCBlockState(block.getDefaultState());
@@ -37,14 +44,12 @@ public class BracketHandlerBlockState implements IBracketHandler {
                 for (String propertyPair : properties.split(",")) {
                     String[] splitPair = propertyPair.split("=");
                     if (splitPair.length != 2) {
-                        CraftTweakerAPI.logWarning("Invalid blockstate property format");
+                        CraftTweakerAPI.logWarning("Invalid blockstate property format '" + propertyPair + "'. Using default property value.");
                         continue;
                     }
                     blockState = blockState.withProperty(splitPair[0], splitPair[1]);
                 }
             }
-        } else {
-            CraftTweakerAPI.logWarning("No block found named " + name);
         }
 
         return blockState;
@@ -69,6 +74,9 @@ public class BracketHandlerBlockState implements IBracketHandler {
                     }
                 } else {
                     blockName = split[1];
+                }
+                if (!ForgeRegistries.BLOCKS.containsKey(new ResourceLocation(blockName))) {
+                    return null;
                 }
                 zenSymbol = new BlockStateReferenceSymbol(environment, blockName, properties);
             }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/MCWorld.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/MCWorld.java
@@ -8,7 +8,6 @@ import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.api.util.Position3f;
 import crafttweaker.api.world.*;
 import crafttweaker.mc1120.data.NBTConverter;
-import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;


### PR DESCRIPTION
* Adds bracket handler for blockstates using property key-value pairs instead of metadata values
* Adds `IBlockStateMatcher` interface for matching blockstates to subsets of property values
* Extends `IBlockState` with `IBlockStateMatcher` and implements necessary methods in MCBlockState
* Adds method to `IWorld` to set tileentity data with setBlockState.

Tested all syntax with a sample script, tested functionality with an integration script with my Morechids mod to test the blockstate matching.