### PR TITLE
Renamed blockstate methods and added missing property lookup features

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
@@ -3,9 +3,7 @@ package crafttweaker.api.block;
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.util.ArrayUtil;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 public class BlockStateMatcherOr implements IBlockStateMatcher {
 
@@ -30,12 +28,6 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
     }
 
     @Override
-    public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
-        CraftTweakerAPI.logWarning("Cannot change allowed values for a compound blockstate matcher");
-        return this;
-    }
-
-    @Override
     public IBlockStateMatcher or(IBlockStateMatcher matcher) {
         return new BlockStateMatcherOr(ArrayUtil.append(elements, matcher));
     }
@@ -51,5 +43,28 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
             matchingStates.addAll(states);
         }
         return matchingStates;
+    }
+
+    @Override
+    public IBlockStateMatcher withMatchedValuesForProperty(String name, String... values) {
+        CraftTweakerAPI.logWarning("Cannot change matched values for a compound blockstate matcher");
+        return this;
+    }
+
+    @Override
+    public List<String> getMatchedValuesForProperty(String name) {
+        CraftTweakerAPI.logWarning("Cannot retrieve matched values for a compound blockstate matcher");
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Map<String, List<String>> getMatchedProperties() {
+        CraftTweakerAPI.logWarning("Cannot retrieve matched values for a compound blockstate matcher");
+        return new HashMap<>();
+    }
+
+    @Override
+    public boolean isCompound() {
+        return true;
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
@@ -46,6 +46,12 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
     }
 
     @Override
+    public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
+        CraftTweakerAPI.logWarning("IBlockStateMatcher#allowValuesForProperty is deprecated. Please use IBlockStateMatcher#withMatchedValuesForProperty instead.");
+        return withMatchedValuesForProperty(name, values);
+    }
+
+    @Override
     public IBlockStateMatcher withMatchedValuesForProperty(String name, String... values) {
         CraftTweakerAPI.logWarning("Cannot change matched values for a compound blockstate matcher");
         return this;

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockState.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockState.java
@@ -4,6 +4,9 @@ import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.world.*;
 import stanhebben.zenscript.annotations.*;
 
+import java.util.List;
+import java.util.Map;
+
 @ZenClass("crafttweaker.block.IBlockState")
 @ZenRegister
 public interface IBlockState extends IBlockProperties, IBlockStateMatcher {
@@ -25,4 +28,16 @@ public interface IBlockState extends IBlockProperties, IBlockStateMatcher {
 
     @ZenMethod
     IBlockState withProperty(String name, String value);
+
+    @ZenMethod
+    List<String> getPropertyNames();
+
+    @ZenMethod
+    String getPropertyValue(String name);
+
+    @ZenMethod
+    List<String> getAllowedValuesForProperty(String name);
+
+    @ZenMethod
+    Map<String, String> getProperties();
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
@@ -20,6 +20,10 @@ public interface IBlockStateMatcher {
     @ZenMethod
     Collection<IBlockState> getMatchingBlockStates();
 
+    @Deprecated
+    @ZenMethod
+    IBlockStateMatcher allowValuesForProperty(String name, String... values);
+
     @ZenMethod
     IBlockStateMatcher withMatchedValuesForProperty(String name, String... values);
 

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
@@ -4,19 +4,31 @@ import crafttweaker.annotations.ZenRegister;
 import stanhebben.zenscript.annotations.*;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 @ZenClass("crafttweaker.block.IBlockStateMatcher")
 @ZenRegister
 public interface IBlockStateMatcher {
     @ZenMethod
+    @ZenOperator(OperatorType.CONTAINS)
     boolean matches(IBlockState blockState);
-
-    @ZenMethod
-    IBlockStateMatcher allowValuesForProperty(String name, String... values);
 
     @ZenOperator(OperatorType.OR)
     IBlockStateMatcher or(IBlockStateMatcher matcher);
 
     @ZenMethod
     Collection<IBlockState> getMatchingBlockStates();
+
+    @ZenMethod
+    IBlockStateMatcher withMatchedValuesForProperty(String name, String... values);
+
+    @ZenMethod
+    List<String> getMatchedValuesForProperty(String name);
+
+    @ZenMethod
+    Map<String, List<String>> getMatchedProperties();
+
+    @ZenMethod
+    boolean isCompound();
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -57,16 +57,6 @@ public class BlockStateMatcher implements IBlockStateMatcher {
     }
 
     @Override
-    public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
-        Map<String, List<String>> newProps = new HashMap<>();
-        for (Map.Entry<String, List<String>> entry : allowedProperties.entrySet()) {
-            newProps.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
-        }
-        newProps.put(name, ImmutableList.copyOf(values));
-        return new BlockStateMatcher(blockState, newProps);
-    }
-
-    @Override
     public IBlockStateMatcher or(IBlockStateMatcher matcher) {
         return new BlockStateMatcherOr(this, matcher);
     }
@@ -79,5 +69,37 @@ public class BlockStateMatcher implements IBlockStateMatcher {
                 .map(MCBlockState::new)
                 .filter(this::matches)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public IBlockStateMatcher withMatchedValuesForProperty(String name, String... values) {
+        Map<String, List<String>> newProps = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry : allowedProperties.entrySet()) {
+            newProps.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
+        }
+        newProps.put(name, ImmutableList.copyOf(values));
+        return new BlockStateMatcher(blockState, newProps);
+    }
+
+    @Override
+    public List<String> getMatchedValuesForProperty(String name) {
+        if (allowedProperties.containsKey(name)) {
+            return ImmutableList.copyOf(allowedProperties.get(name));
+        }
+        return ImmutableList.of("*");
+    }
+
+    @Override
+    public Map<String, List<String>> getMatchedProperties() {
+        Map<String, List<String>> props = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry : allowedProperties.entrySet()) {
+            props.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
+        }
+        return ImmutableMap.copyOf(props);
+    }
+
+    @Override
+    public boolean isCompound() {
+        return false;
     }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -2,6 +2,7 @@ package crafttweaker.mc1120.block;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.block.*;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;
@@ -69,6 +70,12 @@ public class BlockStateMatcher implements IBlockStateMatcher {
                 .map(MCBlockState::new)
                 .filter(this::matches)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
+        CraftTweakerAPI.logWarning("IBlockStateMatcher#allowValuesForProperty is deprecated. Please use IBlockStateMatcher#withMatchedValuesForProperty instead.");
+        return withMatchedValuesForProperty(name, values);
     }
 
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -84,7 +84,13 @@ public class BlockStateMatcher implements IBlockStateMatcher {
         for (Map.Entry<String, List<String>> entry : allowedProperties.entrySet()) {
             newProps.put(entry.getKey(), ImmutableList.copyOf(entry.getValue()));
         }
-        newProps.put(name, ImmutableList.copyOf(values));
+        List<String> newValues = ImmutableList.copyOf(values);
+        if (newValues.contains("*") && newValues.size() > 1) {
+            newProps.put(name, ImmutableList.of("*"));
+        } else {
+            newProps.put(name, newValues);
+        }
+
         return new BlockStateMatcher(blockState, newProps);
     }
 

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -134,7 +134,12 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     @Override
     public IBlockStateMatcher withMatchedValuesForProperty(String name, String... values) {
         Map<String, List<String>> newProps = new HashMap<>();
-        newProps.put(name, ImmutableList.copyOf(values));
+        List<String> newValues = ImmutableList.copyOf(values);
+        if (newValues.contains("*") && newValues.size() > 1) {
+            newProps.put(name, ImmutableList.of("*"));
+        } else {
+            newProps.put(name, newValues);
+        }
         return new BlockStateMatcher(this, newProps);
     }
 

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -78,7 +78,11 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
 
     @Override
     public List<String> getPropertyNames() {
-        return null;
+        List<String> props = new ArrayList<>();
+        for (IProperty prop : blockState.getPropertyKeys()) {
+            props.add(prop.getName());
+        }
+        return ImmutableList.copyOf(props);
     }
 
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -85,6 +85,7 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     public String getPropertyValue(String name) {
         IProperty prop = blockState.getBlock().getBlockState().getProperty(name);
         if (prop != null) {
+            //noinspection unchecked
             return blockState.getValue(prop).toString();
         }
         CraftTweakerAPI.logWarning("Invalid property name");
@@ -95,6 +96,7 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     public List<String> getAllowedValuesForProperty(String name) {
         IProperty prop = blockState.getBlock().getBlockState().getProperty(name);
         List<String> values = new ArrayList<>();
+        //noinspection unchecked
         prop.getAllowedValues().forEach(v -> values.add(v.toString()));
         return values;
     }
@@ -121,6 +123,12 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     @Override
     public Collection<crafttweaker.api.block.IBlockState> getMatchingBlockStates() {
         return ImmutableList.of(this);
+    }
+
+    @Override
+    public IBlockStateMatcher allowValuesForProperty(String name, String... values) {
+        CraftTweakerAPI.logWarning("IBlockStateMatcher#allowValuesForProperty is deprecated. Please use IBlockStateMatcher#withMatchedValuesForProperty instead.");
+        return withMatchedValuesForProperty(name, values);
     }
 
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -99,10 +99,14 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     @Override
     public List<String> getAllowedValuesForProperty(String name) {
         IProperty prop = blockState.getBlock().getBlockState().getProperty(name);
-        List<String> values = new ArrayList<>();
-        //noinspection unchecked
-        prop.getAllowedValues().forEach(v -> values.add(v.toString()));
-        return values;
+        if (prop != null) {
+            List<String> values = new ArrayList<>();
+            //noinspection unchecked
+            prop.getAllowedValues().forEach(v -> values.add(v.toString()));
+            return values;
+        }
+        CraftTweakerAPI.logWarning("Invalid property name");
+        return ImmutableList.of();
     }
 
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -2,6 +2,7 @@ package crafttweaker.mc1120.block;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.block.*;
 import crafttweaker.api.world.*;
@@ -76,15 +77,40 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     }
 
     @Override
-    public boolean matches(crafttweaker.api.block.IBlockState other) {
-        return compare(other) == 0;
+    public List<String> getPropertyNames() {
+        return null;
     }
 
     @Override
-    public IBlockStateMatcher allowValuesForProperty(String propertyName, String... propertyValues) {
-        Map<String, List<String>> newProps = new HashMap<>();
-        newProps.put(propertyName, ImmutableList.copyOf(propertyValues));
-        return new BlockStateMatcher(this, newProps);
+    public String getPropertyValue(String name) {
+        IProperty prop = blockState.getBlock().getBlockState().getProperty(name);
+        if (prop != null) {
+            return blockState.getValue(prop).toString();
+        }
+        CraftTweakerAPI.logWarning("Invalid property name");
+        return "";
+    }
+
+    @Override
+    public List<String> getAllowedValuesForProperty(String name) {
+        IProperty prop = blockState.getBlock().getBlockState().getProperty(name);
+        List<String> values = new ArrayList<>();
+        prop.getAllowedValues().forEach(v -> values.add(v.toString()));
+        return values;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        Map<String, String> props = new HashMap<>();
+        for (Map.Entry<IProperty<?>, Comparable<?>> entry : blockState.getProperties().entrySet()) {
+            props.put(entry.getKey().getName(), entry.getValue().toString());
+        }
+        return ImmutableMap.copyOf(props);
+    }
+
+    @Override
+    public boolean matches(crafttweaker.api.block.IBlockState other) {
+        return compare(other) == 0;
     }
 
     @Override
@@ -95,5 +121,31 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     @Override
     public Collection<crafttweaker.api.block.IBlockState> getMatchingBlockStates() {
         return ImmutableList.of(this);
+    }
+
+    @Override
+    public IBlockStateMatcher withMatchedValuesForProperty(String name, String... values) {
+        Map<String, List<String>> newProps = new HashMap<>();
+        newProps.put(name, ImmutableList.copyOf(values));
+        return new BlockStateMatcher(this, newProps);
+    }
+
+    @Override
+    public List<String> getMatchedValuesForProperty(String name) {
+        return ImmutableList.of(getPropertyValue(name));
+    }
+
+    @Override
+    public Map<String, List<String>> getMatchedProperties() {
+        Map<String, List<String>> props = new HashMap<>();
+        for(Map.Entry<String,String> entry : getProperties().entrySet()) {
+            props.put(entry.getKey(), ImmutableList.of(entry.getValue()));
+        }
+        return ImmutableMap.copyOf(props);
+    }
+
+    @Override
+    public boolean isCompound() {
+        return false;
     }
 }


### PR DESCRIPTION
* Renames BlockState and BlockStateMatcher methods to better reflect their function relative to vanilla MC names
* Adds methods to fetch property values and lists of valid properties to assist in blockstate handling and matching
* ~~~Breaks the last version because method names changed. Whups.~~~ Just deprecates stuff.