### PR TITLE
Add convenience method for block matching, and matcher and state toString

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
@@ -70,6 +70,15 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
     }
 
     @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(" | ", "Matcher (", ")");
+        for (IBlockStateMatcher element : elements) {
+            joiner.add(element.toString());
+        }
+        return joiner.toString();
+    }
+
+    @Override
     public boolean isCompound() {
         return true;
     }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockState.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockState.java
@@ -40,4 +40,7 @@ public interface IBlockState extends IBlockProperties, IBlockStateMatcher {
 
     @ZenMethod
     Map<String, String> getProperties();
+    
+    @ZenMethod
+    IBlockStateMatcher matchBlock();
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -112,6 +112,22 @@ public class BlockStateMatcher implements IBlockStateMatcher {
     }
 
     @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("Matcher (");
+        IBlockState state = (IBlockState) blockState.getInternal();
+        builder.append(state.getBlock().getRegistryName());
+        if (!allowedProperties.isEmpty()) {
+            builder.append(":");
+            StringJoiner joiner = new StringJoiner(",");
+            for (Map.Entry<String, List<String>> entry : allowedProperties.entrySet()) {
+                joiner.add(entry.getKey() + "=" + entry.getValue());
+            }
+            builder.append(joiner);
+        }
+        return builder.append(")").toString();
+    }
+
+    @Override
     public boolean isCompound() {
         return false;
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -119,6 +119,11 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     }
 
     @Override
+    public IBlockStateMatcher matchBlock() {
+        return new BlockStateMatcher(this);
+    }
+
+    @Override
     public boolean matches(crafttweaker.api.block.IBlockState other) {
         return compare(other) == 0;
     }
@@ -163,6 +168,21 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
             props.put(entry.getKey(), ImmutableList.of(entry.getValue()));
         }
         return ImmutableMap.copyOf(props);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("<blockstate:");
+        builder.append(blockState.getBlock().getRegistryName());
+        if (!blockState.getProperties().isEmpty()) {
+            builder.append(":");
+            StringJoiner joiner = new StringJoiner(",");
+            for (Map.Entry<IProperty<?>, Comparable<?>> entry : blockState.getProperties().entrySet()) {
+                joiner.add(entry.getKey().getName() + "=" + entry.getValue());
+            }
+            builder.append(joiner);
+        }
+        return builder.append(">").toString();
     }
 
     @Override


### PR DESCRIPTION
This simple PR does two things:
* Adds a `matchBlock()` method to CT's IBlockState, which creates a matcher matching that block ignoring blockstate properties. While it is already doable with `IBlockStateMatcher.create(<blockstate:minecraft:dirt>)`, this option is unwieldy and not really clear in the intent - before taking a closer look and asking, I thought that it makes a matcher that only takes the provided states, but using a single state is specialcased... (WIP docs at the moment don't help)
* Overrides `toString()` on block states and matchers to make more meaningful log messages easier. 