### PR TITLE
Allow specification of group for recipe names for Botania, etc, compatibility

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/recipes/IRecipeManager.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/recipes/IRecipeManager.java
@@ -56,6 +56,19 @@ public interface IRecipeManager {
     void addShaped(String name, IItemStack output, IIngredient[][] ingredients, @Optional IRecipeFunction function, @Optional IRecipeAction action);
     
     /**
+     * Adds a shaped recipe specifying group.
+     *
+     * @param group       recipe group
+     * @param name        recipe name
+     * @param output      recipe output
+     * @param ingredients recipe ingredients
+     * @param function    recipe function (optional)
+     */
+    @ZenDoc("Adds a shaped recipe.")
+    @ZenMethod
+    void addShaped(String group, String name, IItemStack output, IIngredient[][] ingredients, @Optional IRecipeFunction function, @Optional IRecipeAction action);
+
+    /**
      * Adds a mirrored shaped recipe.
      *
      * @param output      recipe output
@@ -94,7 +107,19 @@ public interface IRecipeManager {
      */
     @ZenMethod
     void addShapeless(String name, IItemStack output, IIngredient[] ingredients, @Optional IRecipeFunction function, @Optional IRecipeAction action);
-    
+
+     /**
+     * Adds a shapeless recipe with a group.
+     *
+     * @param group       recipe group
+     * @param name        recipe name
+     * @param output      recipe output
+     * @param ingredients recipe ingredients
+     * @param function    recipe function (optional)
+     */
+    @ZenMethod
+    void addShapeless(String group, String name, IItemStack output, IIngredient[] ingredients, @Optional IRecipeFunction function, @Optional IRecipeAction action);
+
     /**
      * @param name        recipe name
      * @param output      recipe output

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeManager.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeManager.java
@@ -135,6 +135,13 @@ public final class MCRecipeManager implements IRecipeManager {
     public void addShaped(String name, IItemStack output, IIngredient[][] ingredients, @Optional IRecipeFunction function, @Optional IRecipeAction action) {
         recipesToAdd.add(new ActionAddShapedRecipe(name, output, ingredients, function, action, false, false));
     }
+
+    @Override
+    public void addShaped(String group, String name, IItemStack output, IIngredient[][] ingredients, @Optional IRecipeFunction function, @Optional IRecipeAction action) {
+        ActionAddShapedRecipe recipe = new ActionAddShapedRecipe(name, output, ingredients, function, action, false, false);
+        recipe.setGroup(group);
+        recipesToAdd.add(recipe);
+    }
     
     @Override
     public void addShapedMirrored(IItemStack output, IIngredient[][] ingredients, @Optional IRecipeFunction function, @Optional IRecipeAction action) {
@@ -174,6 +181,23 @@ public final class MCRecipeManager implements IRecipeManager {
             return;
         }
         recipesToAdd.add(new ActionAddShapelessRecipe(name, output, ingredients, function, action, false));
+    }
+
+    @Override
+    public void addShapeless(String group, String name, IItemStack output, IIngredient[] ingredients, @Optional IRecipeFunction function, @Optional IRecipeAction action) {
+        boolean valid = output != null;
+        for(IIngredient ing : ingredients) {
+            if(ing == null) {
+                valid = false;
+            }
+        }
+        if(!valid) {
+            CraftTweakerAPI.logError("Null not allowed in shapeless recipes! Recipe for: " + output + " not created!");
+            return;
+        }
+        ActionAddShapelessRecipe recipe = new ActionAddShapelessRecipe(name, output, ingredients, function, action, false);
+        recipe.setGroup(group);
+        recipesToAdd.add(recipe);
     }
     
     @Override
@@ -755,6 +779,7 @@ public final class MCRecipeManager implements IRecipeManager {
         protected IItemStack output;
         protected boolean isShaped;
         protected String name;
+        protected String group = "crafttweaker";
         
         @Deprecated
         public ActionBaseAddRecipe() {
@@ -778,6 +803,12 @@ public final class MCRecipeManager implements IRecipeManager {
         
         public String getName() {
             return name;
+        }
+
+        public void setGroup(String group) {
+            if (group != null) {
+                this.group = group;
+            }
         }
         
         protected void setName(String name) {
@@ -806,7 +837,7 @@ public final class MCRecipeManager implements IRecipeManager {
         
         @Override
         public void apply() {
-            ForgeRegistries.RECIPES.register(recipe.setRegistryName(new ResourceLocation("crafttweaker", name)));
+            ForgeRegistries.RECIPES.register(recipe.setRegistryName(new ResourceLocation(group, name)));
         }
         
         @Override
@@ -840,7 +871,7 @@ public final class MCRecipeManager implements IRecipeManager {
         protected void setName(String name) {
             super.setName(name);
             //This is necessary to allow recipe name progression if we repeatedly modify a recipe.
-            recipe.setRegistryName(new ResourceLocation("crafttweaker", this.name));
+            recipe.setRegistryName(new ResourceLocation(group, this.name));
         }
     }
     


### PR DESCRIPTION
As many in-game guides are hardcoded to display recipes with specific recipe IDs, modifying these recipes by removing them and adding replacements can result in broken guides as all new recipes, by default, are hardcoded to have the group "crafttweaker".

This patch hopefully brings CraftTweaker in line with ModTweaker's recent changes to Thaumcraft functions for preserving recipe visibility in the Thaumonomicon.

I've been using this modified version of CraftTweaker locally for the past few months as a way of testing it, and as far as I can tell it doesn't introduce any issues. Hopefully it is up to standards!