### PR TITLE
Two Events; Allows liquidsStacks in recipes; Some minor fixes

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/CraftTweakerAPI.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/CraftTweakerAPI.java
@@ -19,6 +19,7 @@ import stanhebben.zenscript.type.natives.*;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
+import java.util.Arrays;
 import java.util.logging.*;
 
 /**
@@ -330,5 +331,18 @@ public class CraftTweakerAPI {
      */
     public static IJavaMethod getJavaMethod(Class<? extends IBracketHandler> cls, String name, Class... arguments) {
         return JavaMethod.get(GlobalRegistry.getTypes(), cls, name, arguments);
+    }
+    
+    /**
+     * Gets a string representation of the Script file and line from the current stacktrace.
+     * Only works if the current Stacktrace actually has a script within, otherwise returns
+     * @return The filename and line number of the originating script.
+     */
+    public static String getScriptFileAndLine() {
+        return Arrays.stream(Thread.currentThread().getStackTrace())
+                .filter(s -> s != null && s.getFileName() != null && s.getFileName().endsWith(".zs"))
+                .findFirst()
+                .map(s -> s.getFileName() + ":" + s.getLineNumber())
+                .orElse("<?>");
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/BlockStateMatcherOr.java
@@ -4,6 +4,7 @@ import crafttweaker.CraftTweakerAPI;
 import crafttweaker.util.ArrayUtil;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class BlockStateMatcherOr implements IBlockStateMatcher {
 
@@ -81,5 +82,14 @@ public class BlockStateMatcherOr implements IBlockStateMatcher {
     @Override
     public boolean isCompound() {
         return true;
+    }
+    
+    @Override
+    public String toCommandString() {
+        StringJoiner joiner = new StringJoiner(" | ");
+        for(IBlockStateMatcher element : elements) {
+            joiner.add(element.toCommandString());
+        }
+        return joiner.toString();
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockStateMatcher.java
@@ -1,5 +1,6 @@
 package crafttweaker.api.block;
 
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.ZenRegister;
 import stanhebben.zenscript.annotations.*;
 
@@ -35,4 +36,10 @@ public interface IBlockStateMatcher {
 
     @ZenMethod
     boolean isCompound();
+    
+    @ZenGetter("commandString")
+    default String toCommandString() {
+        CraftTweakerAPI.logError(this.getClass() + " does not overwrite IBlockStateMatcher#toCommandString");
+        return toString();
+    }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/enchantments/IEnchantmentDefinition.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/enchantments/IEnchantmentDefinition.java
@@ -11,6 +11,9 @@ public interface IEnchantmentDefinition {
     @ZenGetter("id")
     int getID();
     
+    @ZenGetter("registryName")
+    String getRegistryName();
+    
     @ZenGetter("name")
     String getName();
     
@@ -53,6 +56,9 @@ public interface IEnchantmentDefinition {
     @ZenOperator(OperatorType.MUL)
     @ZenMethod
     IEnchantment makeEnchantment(int level);
+    
+    @ZenOperator(OperatorType.COMPARE)
+    int compare(IEnchantmentDefinition other);
     
     Object getInternal();
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntity.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntity.java
@@ -481,8 +481,14 @@ public interface IEntity extends ICommandSender {
     @ZenGetter("lookingDirection")
     IVector3d getLookingDirection();
     
-    @ZenMethod
+    @Deprecated
     IRayTraceResult getRayTrace(double blockReachDistance, float partialTicks);
+    
+    @ZenMethod
+    default IRayTraceResult getRayTrace(double blockReachDistance, float partialTicks, @Optional boolean stopOnLiquid, @Optional boolean ignoreBlockWithoutBoundingBox, @Optional(valueBoolean = true) boolean returnLastUncollidableBlock) {
+        CraftTweakerAPI.logError(this.getClass().getName() + " does not properly implement IEntity#getRayTrace, ask the author to fix this");
+        return getRayTrace(blockReachDistance, partialTicks);
+    }
     
     @ZenMethod
     default void update(IData data){

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntity.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/entity/IEntity.java
@@ -1,5 +1,6 @@
 package crafttweaker.api.entity;
 
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.block.*;
 import crafttweaker.api.command.ICommandSender;
@@ -482,4 +483,9 @@ public interface IEntity extends ICommandSender {
     
     @ZenMethod
     IRayTraceResult getRayTrace(double blockReachDistance, float partialTicks);
+    
+    @ZenMethod
+    default void update(IData data){
+        CraftTweakerAPI.logError("IEntity#update not overwritten by implementation " + this.getClass() + "!");
+    }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/EntityLivingSpawnEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/EntityLivingSpawnEvent.java
@@ -1,0 +1,45 @@
+package crafttweaker.api.event;
+
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.tileentity.IMobSpawnerBaseLogic;
+import crafttweaker.api.world.IWorld;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenGetter;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("crafttweaker.event.EntityLivingSpawnEvent")
+@ZenRegister
+public interface EntityLivingSpawnEvent extends ILivingEvent {
+    
+    @ZenGetter("world")
+    IWorld getWorld();
+    
+    @ZenGetter("x")
+    float getX();
+    
+    @ZenGetter("y")
+    float getY();
+    
+    @ZenGetter("z")
+    float getZ();
+    
+    @ZenClass("crafttweaker.event.EntityLivingExtendedSpawnEvent")
+    @ZenRegister
+    interface EntityLivingExtendedSpawnEvent extends EntityLivingSpawnEvent {
+        @ZenGetter("spawner")
+        IMobSpawnerBaseLogic getSpawner();
+    }
+    
+    @ZenClass("crafttweaker.event.EntityLivingAllowDespawnEvent")
+    @ZenRegister
+    interface EntityLivingAllowDespawnEvent extends EntityLivingSpawnEvent {
+        @ZenMethod
+        void forceDespawn();
+        
+        @ZenMethod
+        void forceRemain();
+        
+        @ZenMethod
+        void pass();
+    }
+}

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/EntityLivingSpawnEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/EntityLivingSpawnEvent.java
@@ -23,23 +23,20 @@ public interface EntityLivingSpawnEvent extends ILivingEvent {
     @ZenGetter("z")
     float getZ();
     
+    @ZenMethod
+    void allow();
+    
+    @ZenMethod
+    void deny();
+    
+    @ZenMethod
+    void pass();
+    
     @ZenClass("crafttweaker.event.EntityLivingExtendedSpawnEvent")
     @ZenRegister
     interface EntityLivingExtendedSpawnEvent extends EntityLivingSpawnEvent {
+        
         @ZenGetter("spawner")
         IMobSpawnerBaseLogic getSpawner();
-    }
-    
-    @ZenClass("crafttweaker.event.EntityLivingAllowDespawnEvent")
-    @ZenRegister
-    interface EntityLivingAllowDespawnEvent extends EntityLivingSpawnEvent {
-        @ZenMethod
-        void forceDespawn();
-        
-        @ZenMethod
-        void forceRemain();
-        
-        @ZenMethod
-        void pass();
     }
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/IEventManager.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/IEventManager.java
@@ -149,7 +149,16 @@ public interface IEventManager {
 
     @ZenMethod
     IEventHandle onCommand(IEventHandler<CommandEvent> ev);
-
+    
+    @ZenMethod
+    IEventHandle onCheckSpawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent> ev);
+    
+    @ZenMethod
+    IEventHandle onSpecialSpawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent> ev);
+    
+    @ZenMethod
+    IEventHandle onAllowDespawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent> ev);
+    
     /*
      *
      * IEventHandle onPlayerChat(IPlayerChatEventHandler ev);

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/IEventManager.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/IEventManager.java
@@ -157,7 +157,7 @@ public interface IEventManager {
     IEventHandle onSpecialSpawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent> ev);
     
     @ZenMethod
-    IEventHandle onAllowDespawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent> ev);
+    IEventHandle onAllowDespawn(IEventHandler<EntityLivingSpawnEvent> ev);
     
     /*
      *

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/IEventManager.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/IEventManager.java
@@ -38,6 +38,9 @@ public interface IEventManager {
 
     @ZenMethod
     IEventHandle onPlayerAttackEntity(IEventHandler<PlayerAttackEntityEvent> ev);
+    
+    @ZenMethod
+    IEventHandle onPlayerAdvancement(IEventHandler<PlayerAdvancementEvent> ev);
 
     @ZenMethod
     IEventHandle onPlayerBonemeal(IEventHandler<PlayerBonemealEvent> ev);

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/MTEventManager.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/MTEventManager.java
@@ -927,10 +927,10 @@ public class MTEventManager implements IEventManager {
     // ### AllowDespawn ###
     // ####################
     
-    private final EventList<EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent> elAllowDespawn = new EventList<>();
+    private final EventList<EntityLivingSpawnEvent> elAllowDespawn = new EventList<>();
     
     @Override
-    public IEventHandle onAllowDespawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent> ev) {
+    public IEventHandle onAllowDespawn(IEventHandler<EntityLivingSpawnEvent> ev) {
         return elAllowDespawn.add(ev);
     }
     
@@ -938,7 +938,7 @@ public class MTEventManager implements IEventManager {
         return elAllowDespawn.hasHandlers();
     }
     
-    public void publishAllowDespawn(EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent event) {
+    public void publishAllowDespawn(EntityLivingSpawnEvent event) {
         elAllowDespawn.publish(event);
     }
     

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/MTEventManager.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/MTEventManager.java
@@ -863,6 +863,26 @@ public class MTEventManager implements IEventManager {
     public void publishCommand(CommandEvent event) {
         elCommand.publish(event);
     }
-
-
+    
+    
+    // #########################
+    // ### PlayerAdvancement ###
+    // #########################
+    
+    private final EventList<PlayerAdvancementEvent> elPlayerAdvancement = new EventList<>();
+    
+    @Override
+    public IEventHandle onPlayerAdvancement(IEventHandler<PlayerAdvancementEvent> ev) {
+        return elPlayerAdvancement.add(ev);
+    }
+    
+    public boolean hasPlayerAdvancement() {
+        return elPlayerAdvancement.hasHandlers();
+    }
+    
+    public void publishPlayerAdvancement(PlayerAdvancementEvent event) {
+        elPlayerAdvancement.publish(event);
+    }
+    
+    
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/MTEventManager.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/MTEventManager.java
@@ -884,5 +884,63 @@ public class MTEventManager implements IEventManager {
         elPlayerAdvancement.publish(event);
     }
     
+    // ##################
+    // ### CheckSpawn ###
+    // ##################
+    
+    private final EventList<EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent> elCheckSpawn = new EventList<>();
+    
+    @Override
+    public IEventHandle onCheckSpawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent> ev) {
+        return elCheckSpawn.add(ev);
+    }
+    
+    public boolean hasCheckSpawn() {
+        return elCheckSpawn.hasHandlers();
+    }
+    
+    public void publishCheckSpawn(EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent event) {
+        elCheckSpawn.publish(event);
+    }
+    
+    // ####################
+    // ### SpecialSpawn ###
+    // ####################
+    
+    private final EventList<EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent> elSpecialSpawn = new EventList<>();
+    
+    @Override
+    public IEventHandle onSpecialSpawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent> ev) {
+        return elSpecialSpawn.add(ev);
+    }
+    
+    public boolean hasSpecialSpawn() {
+        return elSpecialSpawn.hasHandlers();
+    }
+    
+    public void publishSpecialSpawn(EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent event) {
+        elSpecialSpawn.publish(event);
+    }
+    
+    
+    // ####################
+    // ### AllowDespawn ###
+    // ####################
+    
+    private final EventList<EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent> elAllowDespawn = new EventList<>();
+    
+    @Override
+    public IEventHandle onAllowDespawn(IEventHandler<EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent> ev) {
+        return elAllowDespawn.add(ev);
+    }
+    
+    public boolean hasAllowDespawn() {
+        return elAllowDespawn.hasHandlers();
+    }
+    
+    public void publishAllowDespawn(EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent event) {
+        elAllowDespawn.publish(event);
+    }
+    
     
 }

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/PlayerAdvancementEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/PlayerAdvancementEvent.java
@@ -1,0 +1,15 @@
+package crafttweaker.api.event;
+
+import crafttweaker.annotations.ZenRegister;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenGetter;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("crafttweaker.event.PlayerAdvancementEvent")
+@ZenRegister
+public interface PlayerAdvancementEvent extends IPlayerEvent {
+    
+    @ZenMethod
+    @ZenGetter("id")
+    String getId();
+}

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientStack.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IngredientStack.java
@@ -77,12 +77,12 @@ public class IngredientStack implements IIngredient {
     
     @Override
     public boolean matches(IItemStack item) {
-        return ingredient.matches(item);
+        return item.getAmount() >= this.getAmount() && ingredient.matches(item);
     }
     
     @Override
     public boolean matchesExact(IItemStack item) {
-        return ingredient.matchesExact(item);
+        return item.getAmount() >= this.getAmount() && ingredient.matchesExact(item);
     }
     
     @Override

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/tileentity/IMobSpawnerBaseLogic.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/tileentity/IMobSpawnerBaseLogic.java
@@ -1,0 +1,35 @@
+package crafttweaker.api.tileentity;
+
+import crafttweaker.api.data.IData;
+import crafttweaker.api.entity.IEntityDefinition;
+import crafttweaker.api.world.IBlockPos;
+import crafttweaker.api.world.IWorld;
+import stanhebben.zenscript.annotations.ZenGetter;
+import stanhebben.zenscript.annotations.ZenMethod;
+import stanhebben.zenscript.annotations.ZenSetter;
+
+public interface IMobSpawnerBaseLogic {
+    
+    @ZenSetter("entityDefinition")
+    void setEntityDefinition(IEntityDefinition entityDefinition);
+    
+    @ZenMethod
+    void updateSpawner();
+    
+    @ZenGetter("nbtData")
+    IData getNbtData();
+    
+    @ZenSetter("nbtData")
+    void setNbtData(IData nbtData);
+    
+    @ZenMethod
+    void setDelayToMin();
+    
+    @ZenGetter("world")
+    IWorld getWorld();
+    
+    @ZenGetter("blockPos")
+    IBlockPos getBlockPos();
+    
+    
+}

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/tileentity/IMobSpawnerBaseLogic.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/tileentity/IMobSpawnerBaseLogic.java
@@ -1,13 +1,14 @@
 package crafttweaker.api.tileentity;
 
+import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.data.IData;
 import crafttweaker.api.entity.IEntityDefinition;
 import crafttweaker.api.world.IBlockPos;
 import crafttweaker.api.world.IWorld;
-import stanhebben.zenscript.annotations.ZenGetter;
-import stanhebben.zenscript.annotations.ZenMethod;
-import stanhebben.zenscript.annotations.ZenSetter;
+import stanhebben.zenscript.annotations.*;
 
+@ZenClass("crafttweaker.tileentity.IMobSpawnerBaseLogic")
+@ZenRegister
 public interface IMobSpawnerBaseLogic {
     
     @ZenSetter("entityDefinition")

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/world/IWorld.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/world/IWorld.java
@@ -1,5 +1,6 @@
 package crafttweaker.api.world;
 
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.block.*;
 import crafttweaker.api.data.IData;
@@ -83,4 +84,10 @@ public interface IWorld extends IBlockAccess {
     
     @ZenMethod
     boolean spawnEntity(IEntity entity);
+    
+    @ZenMethod
+    default IRayTraceResult rayTraceBlocks(IVector3d begin, IVector3d ray, @Optional boolean stopOnLiquid, @Optional boolean ignoreBlockWithoutBoundingBox, @Optional(valueBoolean = true) boolean returnLastUncollidableBlock) {
+        CraftTweakerAPI.logError(this.getClass().getName() + " does not override IWorld.getRayTrace, tell the author to fix that.");
+        return null;
+    }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/api/minecraft/CraftTweakerMC.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/api/minecraft/CraftTweakerMC.java
@@ -51,6 +51,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.*;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.crafting.CompoundIngredient;
 import net.minecraftforge.fluids.*;
 import net.minecraftforge.oredict.*;
 
@@ -574,6 +575,12 @@ public class CraftTweakerMC {
         } else if(ingredient instanceof Ingredient) {
             if(ingredient instanceof OreIngredient)
                 return getOreDict((OreIngredient) ingredient);
+            if(ingredient instanceof CompoundIngredient) {
+                return ((CompoundIngredient) ingredient).getChildren().stream()
+                        .map(CraftTweakerMC::getIIngredient)
+                        .reduce(IngredientUnknown.INSTANCE, IIngredient::or);
+            }
+            
             ItemStack[] matchingStacks = ((Ingredient) ingredient).matchingStacks;
             
             if(ingredient == Ingredient.EMPTY || matchingStacks.length <= 0 || ((Ingredient) ingredient).apply(ItemStack.EMPTY)) {
@@ -591,7 +598,7 @@ public class CraftTweakerMC {
             return null;
         IIngredient out = ingredients[0];
         for(int i = 1; i < ingredients.length; i++) {
-            out = out.or(ingredients[i]);
+            out = out == null ? ingredients[i] : out.or(ingredients[i]);
         }
         return out;
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/api/minecraft/CraftTweakerMC.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/api/minecraft/CraftTweakerMC.java
@@ -941,4 +941,8 @@ public class CraftTweakerMC {
     public static ILiquidDefinition getILiquidDefinition(Fluid fluid) {
         return fluid == null ? null : new MCLiquidDefinition(fluid);
     }
+    
+    public static Biome getBiome(IBiome biome) {
+        return biome == null ? null : biome instanceof MCBiome ? ((MCBiome) biome).getInternal() : Biome.REGISTRY.getObject(new ResourceLocation(biome.getId()));
+    }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/api/minecraft/CraftTweakerMC.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/api/minecraft/CraftTweakerMC.java
@@ -25,6 +25,7 @@ import crafttweaker.mc1120.data.NBTConverter;
 import crafttweaker.mc1120.entity.*;
 import crafttweaker.mc1120.game.MCTeam;
 import crafttweaker.mc1120.item.MCItemStack;
+import crafttweaker.mc1120.item.VanillaIngredient;
 import crafttweaker.mc1120.liquid.*;
 import crafttweaker.mc1120.oredict.MCOreDictEntry;
 import crafttweaker.mc1120.player.MCPlayer;
@@ -52,6 +53,7 @@ import net.minecraft.world.*;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.crafting.CompoundIngredient;
+import net.minecraftforge.common.crafting.IngredientNBT;
 import net.minecraftforge.fluids.*;
 import net.minecraftforge.oredict.*;
 
@@ -609,8 +611,12 @@ public class CraftTweakerMC {
         if(ingredient instanceof IOreDictEntry)
             return new OreIngredient(((IOreDictEntry) ingredient).getName());
         if(ingredient instanceof IItemStack)
-            return Ingredient.fromStacks(getItemStack((IItemStack) ingredient));
-        return Ingredient.fromStacks(getItemStacks(ingredient.getItems()));
+            if(((IItemStack) ingredient).hasTag())
+                return new IngredientNBT(getItemStack(ingredient)){};
+            else
+                return Ingredient.fromStacks(getItemStack((IItemStack) ingredient));
+                
+        return new VanillaIngredient(ingredient);
     }
     
     private static IOreDictEntry getOreDict(OreIngredient oreIngredient) {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/CraftTweaker.java
@@ -136,6 +136,9 @@ public class CraftTweaker {
             MCFurnaceManager.recipesToAdd.forEach(CraftTweakerAPI::apply);
             LATE_ACTIONS.forEach(CraftTweakerAPI::apply);
             MCRecipeManager.recipes = ForgeRegistries.RECIPES.getEntries();
+            
+            //Cleanup
+            MCRecipeManager.cleanUpRecipeList();
         } catch(Exception e) {
             CraftTweaker.LOG.catching(e);
             CraftTweakerAPI.logError("Error while applying actions", e);

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/actions/ActionOreDictRemoveItem.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/actions/ActionOreDictRemoveItem.java
@@ -17,8 +17,7 @@ public class ActionOreDictRemoveItem implements IAction {
     
     @Override
     public void apply() {
-        int oreId = OreDictionary.getOreID(id);
-        MCOreDictEntry.getOredictContents().get(oreId).remove(item);
+        OreDictionary.getOres(id, false).remove(item);
     }
     
     

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/BlockStateMatcher.java
@@ -131,4 +131,19 @@ public class BlockStateMatcher implements IBlockStateMatcher {
     public boolean isCompound() {
         return false;
     }
+    
+    @Override
+    public String toCommandString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(this.blockState.toCommandString());
+        if (!allowedProperties.isEmpty()) {
+            for(Map.Entry<String, List<String>> allowedProperty : allowedProperties.entrySet()) {
+                builder.append(".withMatchedValuesForProperty(");
+                builder.append(allowedProperty.getKey()).append(", ");
+                builder.append(allowedProperty.getValue().toString());
+                builder.append(")");
+            }
+        }
+        return builder.toString();
+    }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -189,4 +189,9 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     public boolean isCompound() {
         return false;
     }
+    
+    @Override
+    public String toCommandString() {
+        return toString();
+    }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/Commands.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/Commands.java
@@ -863,6 +863,8 @@ public class Commands {
             }
         });
         
+       CTChatCommand.registerCommand(new GiveCommand());
+        
         CTChatCommand.registerCommand(new DumpZsCommand(new TargetLog(), new TargetHtml(), new TargetJson()));
         CTChatCommand.registerCommand(new HelpCommand());
 

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/GiveCommand.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/GiveCommand.java
@@ -1,0 +1,61 @@
+package crafttweaker.mc1120.commands;
+
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.mc1120.brackets.BracketHandlerItem;
+import crafttweaker.mc1120.data.StringIDataParser;
+import crafttweaker.mc1120.player.MCPlayer;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+
+import static crafttweaker.mc1120.commands.SpecialMessagesChat.getClickableCommandText;
+import static crafttweaker.mc1120.commands.SpecialMessagesChat.getNormalMessage;
+
+public class GiveCommand extends CraftTweakerCommand {
+    
+    GiveCommand() {
+        super("give");
+    }
+    
+    @Override
+    protected void init() {
+        setDescription(getClickableCommandText("\u00A72/ct give", "/ct give", true), getNormalMessage(" \u00A73Gives an item using the BH"));
+    }
+    
+    @Override
+    public void executeCommand(MinecraftServer server, ICommandSender sender, String[] args) {
+        //Get the whole string, with whitespaces
+        final String s = String.join(" ", args);
+        
+        //Quick check, doesn't cover the Tag part though.
+        if(!s.matches("<\\w+:\\w+(:\\d+)?>(.withTag\\(\\{.*}\\))?")) {
+            sender.sendMessage(getNormalMessage("Invalid string " + s));
+            return;
+        }
+        
+        if(!(sender instanceof EntityPlayerMP)) {
+            sender.sendMessage(getNormalMessage("Only players can execute this command!"));
+            return;
+        }
+        
+        //Get item
+        final String[] exParts = s.split(">", 2)[0].substring(1).split(":");
+        final String call = exParts[0] + ":" + exParts[1];
+        final int meta = exParts.length > 2 ? Integer.parseInt(exParts[2]) : 0;
+        IItemStack item = BracketHandlerItem.getItem(call, meta);
+        if(item == null) {
+            sender.sendMessage(getNormalMessage("Could not find item: " + call));
+            return;
+        }
+        
+        //Should we apply a tag?
+        if(s.contains("withTag")) {
+            //Remove the withTag and the round brackets so that we get only the tag.
+            final String expression = s.split("withTag\\(")[1];
+            item = item.withTag(StringIDataParser.parse(expression.substring(0, expression.length() - 1)), false);
+        }
+        
+        new MCPlayer((EntityPlayer) sender).give(item);
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/NamesCommand.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/NamesCommand.java
@@ -220,7 +220,11 @@ public class NamesCommand extends CraftTweakerCommand {
         
         ENCHANTABILITY("enchantability", stack -> Integer.toString(stack.getItem().getItemEnchantability(stack))),
         
-        BURN_TIME("burntime", stack -> Integer.toString(TileEntityFurnace.getItemBurnTime(stack)));
+        BURN_TIME("burntime", stack -> Integer.toString(TileEntityFurnace.getItemBurnTime(stack))),
+        
+        FOOD_VALUE("foodvalue", stack -> Integer.toString((stack.getItem() instanceof ItemFood) ? ((ItemFood)stack.getItem()).getHealAmount(stack) : -1)),
+        
+        SATURATION_VALUE("saturationvalue", stack -> Float.toString((stack.getItem() instanceof ItemFood) ? ((ItemFood)stack.getItem()).getSaturationModifier(stack) : -1f));
     
     
         /**

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/data/StringIDataParser.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/data/StringIDataParser.java
@@ -1,0 +1,100 @@
+package crafttweaker.mc1120.data;
+
+import crafttweaker.api.data.*;
+import stanhebben.zenscript.ZenTokener;
+import stanhebben.zenscript.parser.Token;
+
+import java.io.IOException;
+import java.util.*;
+
+import static stanhebben.zenscript.ZenTokener.*;
+
+public class StringIDataParser {
+    
+    public static IData parse(String expression) {
+        try {
+            final ZenTokener zenTokener = new ZenTokener(expression, null, "", false);
+            return parse(zenTokener);
+        } catch(IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+    
+    private static IData parse(ZenTokener tokener) {
+        final Token next = tokener.next();
+        final IData base;
+        switch(next.getType()) {
+            case T_AOPEN:
+                base = parseMap(tokener);
+                break;
+            case T_SQBROPEN:
+                base = parseList(tokener);
+                break;
+            case T_TRUE:
+                base = new DataBool(true);
+                break;
+            case T_FALSE:
+                base = new DataBool(false);
+                break;
+            case T_INTVALUE:
+                base = new DataLong(Long.parseLong(next.getValue(), 10));
+                break;
+            case T_FLOATVALUE:
+                base = new DataDouble(Double.parseDouble(next.getValue()));
+                break;
+            default:
+                return new DataMap(Collections.emptyMap(), true);
+        }
+        
+        if(tokener.optional(T_AS) != null) {
+            final Token token = tokener.next();
+            switch(token.getType()) {
+                case T_BOOL:
+                    return new DataBool(base.asBool());
+                case T_BYTE:
+                    return new DataByte(base.asByte());
+                case T_SHORT:
+                    return new DataShort(base.asShort());
+                case T_INT:
+                    return new DataInt(base.asInt());
+                case T_LONG:
+                    return new DataLong(base.asLong());
+                case T_FLOAT:
+                    return new DataFloat(base.asFloat());
+                case T_STRING:
+                    return new DataString(base.asString());
+                case T_ID:
+                    return base;
+            }
+        }
+        return base;
+    }
+    
+    private static IData parseList(ZenTokener tokener) {
+        final List<IData> result = new ArrayList<>();
+        while(tokener.optional(T_SQBRCLOSE) == null) {
+            result.add(parse(tokener));
+            if(tokener.optional(T_COMMA) == null) {
+                tokener.required(T_SQBRCLOSE, "] expected");
+                break;
+            }
+        }
+        return new DataList(result, false);
+    }
+    
+    private static IData parseMap(ZenTokener tokener) {
+        final Map<String, IData> result = new HashMap<>();
+        while(tokener.optional(T_ACLOSE) == null) {
+            final String key = tokener.required(T_ID, "Identifier expected").getValue();
+            tokener.required(T_COLON, ": expected");
+            result.put(key, parse(tokener));
+            
+            if(tokener.optional(T_COMMA) == null) {
+                tokener.required(T_ACLOSE, "} expected");
+                break;
+            }
+        }
+        return new DataMap(result, false);
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/enchantments/MCEnchantmentDefinition.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/enchantments/MCEnchantmentDefinition.java
@@ -1,9 +1,11 @@
 package crafttweaker.mc1120.enchantments;
 
-import crafttweaker.api.enchantments.*;
+import crafttweaker.api.enchantments.IEnchantment;
+import crafttweaker.api.enchantments.IEnchantmentDefinition;
 import crafttweaker.api.item.IItemStack;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 
 public class MCEnchantmentDefinition implements IEnchantmentDefinition {
     
@@ -20,6 +22,12 @@ public class MCEnchantmentDefinition implements IEnchantmentDefinition {
     @Override
     public int getID() {
         return Enchantment.getEnchantmentID(enchantment);
+    }
+    
+    @Override
+    public String getRegistryName() {
+        final ResourceLocation registryName = enchantment.getRegistryName();
+        return registryName != null ? registryName.toString() : null;
     }
     
     @Override
@@ -90,6 +98,11 @@ public class MCEnchantmentDefinition implements IEnchantmentDefinition {
     @Override
     public IEnchantment makeEnchantment(int level) {
         return new MCEnchantment(enchantment, level);
+    }
+    
+    @Override
+    public int compare(IEnchantmentDefinition other) {
+        return Integer.compare(this.getID(), other.getID());
     }
     
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/entity/MCEntity.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/entity/MCEntity.java
@@ -10,6 +10,7 @@ import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.api.server.IServer;
 import crafttweaker.api.util.Position3f;
 import crafttweaker.api.world.*;
+import crafttweaker.mc1120.CraftTweaker;
 import crafttweaker.mc1120.command.MCCommandSender;
 import crafttweaker.mc1120.data.NBTConverter;
 import crafttweaker.mc1120.server.MCServer;
@@ -370,6 +371,15 @@ public class MCEntity extends MCCommandSender implements IEntity {
     @Override
     public IRayTraceResult getRayTrace(double blockReachDistance, float partialTicks) {
         return CraftTweakerMC.getIRayTraceResult(entity.rayTrace(blockReachDistance, partialTicks));
+    }
+    
+    @Override
+    public IRayTraceResult getRayTrace(double blockReachDistance, float partialTicks, boolean stopOnLiquid, boolean ignoreBlockWithoutBoundingBox, boolean returnLastUncollidableBlock) {
+        //Stolen from Entity
+        Vec3d positionEyes = this.entity.getPositionEyes(partialTicks);
+        Vec3d lookingDirection = this.entity.getLook(partialTicks);
+        Vec3d lookingVector = positionEyes.addVector(lookingDirection.x * blockReachDistance, lookingDirection.y * blockReachDistance, lookingDirection.z * blockReachDistance);
+        return CraftTweakerMC.getIRayTraceResult(this.entity.world.rayTraceBlocks(positionEyes, lookingVector, stopOnLiquid, ignoreBlockWithoutBoundingBox, returnLastUncollidableBlock));
     }
     
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/entity/MCEntity.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/entity/MCEntity.java
@@ -642,6 +642,11 @@ public class MCEntity extends MCCommandSender implements IEntity {
     }
     
     @Override
+    public void update(IData data) {
+        NBTConverter.updateMap(entity.getEntityData(), data);
+    }
+    
+    @Override
     public boolean equals(Object obj) {
         return (obj instanceof MCEntity && entity.isEntityEqual(((MCEntity) obj).entity)) || super.equals(obj);
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
@@ -432,13 +432,13 @@ public class CommonEventHandler {
     @SubscribeEvent
     public void onSpecialSpawnEvent(LivingSpawnEvent.SpecialSpawn ev) {
         if(CrafttweakerImplementationAPI.events.hasSpecialSpawn())
-            CrafttweakerImplementationAPI.events.publishSpecialSpawn(new MCEntityLivingSpawnEvent.MCEntityLivingExtendedSpawnEvent(ev));
+            CrafttweakerImplementationAPI.events.publishSpecialSpawn(new MCEntityLivingSpawnEvent.MCEntityLivingSpecialSpawnEvent(ev));
     }
     
     @SubscribeEvent
     public void onAllowDespawnEvent(LivingSpawnEvent.AllowDespawn ev) {
         if(CrafttweakerImplementationAPI.events.hasAllowDespawn())
-            CrafttweakerImplementationAPI.events.publishAllowDespawn(new MCEntityLivingSpawnEvent.MCEntityLivingAllowDespawnEvent(ev));
+            CrafttweakerImplementationAPI.events.publishAllowDespawn(new MCEntityLivingSpawnEvent(ev));
     }
     
     

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
@@ -20,6 +20,7 @@ import crafttweaker.mc1120.recipes.MCCraftingInventorySquared;
 import crafttweaker.mc1120.recipes.MCRecipeBase;
 import crafttweaker.mc1120.recipes.MCRecipeManager;
 import crafttweaker.runtime.ScriptLoader;
+import net.minecraft.advancements.PlayerAdvancements;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.item.EntityItem;
@@ -415,6 +416,12 @@ public class CommonEventHandler {
         if(CrafttweakerImplementationAPI.events.hasCommand())
             CrafttweakerImplementationAPI.events.publishCommand(new MCCommandEvent(ev));
     }
-
-
+    
+    @SubscribeEvent
+    public void onPlayerAdvancementEvent(AdvancementEvent ev) {
+        if(CrafttweakerImplementationAPI.events.hasPlayerAdvancement())
+            CrafttweakerImplementationAPI.events.publishPlayerAdvancement(new MCPlayerAdvancementEvent(ev));
+    }
+    
+    
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
@@ -423,5 +423,23 @@ public class CommonEventHandler {
             CrafttweakerImplementationAPI.events.publishPlayerAdvancement(new MCPlayerAdvancementEvent(ev));
     }
     
+    @SubscribeEvent
+    public void onCheckSpawnEvent(LivingSpawnEvent.CheckSpawn ev) {
+        if(CrafttweakerImplementationAPI.events.hasCheckSpawn())
+            CrafttweakerImplementationAPI.events.publishCheckSpawn(new MCEntityLivingSpawnEvent.MCEntityLivingExtendedSpawnEvent(ev));
+    }
+    
+    @SubscribeEvent
+    public void onSpecialSpawnEvent(LivingSpawnEvent.SpecialSpawn ev) {
+        if(CrafttweakerImplementationAPI.events.hasSpecialSpawn())
+            CrafttweakerImplementationAPI.events.publishSpecialSpawn(new MCEntityLivingSpawnEvent.MCEntityLivingExtendedSpawnEvent(ev));
+    }
+    
+    @SubscribeEvent
+    public void onAllowDespawnEvent(LivingSpawnEvent.AllowDespawn ev) {
+        if(CrafttweakerImplementationAPI.events.hasAllowDespawn())
+            CrafttweakerImplementationAPI.events.publishAllowDespawn(new MCEntityLivingSpawnEvent.MCEntityLivingAllowDespawnEvent(ev));
+    }
+    
     
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCEntityLivingSpawnEvent.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCEntityLivingSpawnEvent.java
@@ -11,7 +11,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 
 public class MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent {
     
-    private final LivingSpawnEvent event;
+    protected final LivingSpawnEvent event;
     
     public MCEntityLivingSpawnEvent(LivingSpawnEvent event) {
         this.event = event;
@@ -38,6 +38,21 @@ public class MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent {
     }
     
     @Override
+    public void allow() {
+        event.setResult(Event.Result.ALLOW);
+    }
+    
+    @Override
+    public void deny() {
+        event.setResult(Event.Result.DENY);
+    }
+    
+    @Override
+    public void pass() {
+        event.setResult(Event.Result.DEFAULT);
+    }
+    
+    @Override
     public IEntityLivingBase getEntityLivingBase() {
         return CraftTweakerMC.getIEntityLivingBase(event.getEntityLiving());
     }
@@ -45,7 +60,7 @@ public class MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent {
     public static class MCEntityLivingExtendedSpawnEvent extends MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent {
     
         private final IMobSpawnerBaseLogic spawnerBaseLogic;
-        
+    
         public MCEntityLivingExtendedSpawnEvent(LivingSpawnEvent.CheckSpawn event) {
             super(event);
             spawnerBaseLogic = event.getSpawner() == null ? null : new MCMobSpawnerBaseLogic(event.getSpawner());
@@ -62,28 +77,24 @@ public class MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent {
         }
     }
     
-    public static class MCEntityLivingAllowDespawnEvent extends MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent {
+    public static class MCEntityLivingSpecialSpawnEvent extends MCEntityLivingExtendedSpawnEvent {
     
-        private final LivingSpawnEvent.AllowDespawn event;
-    
-        public MCEntityLivingAllowDespawnEvent(LivingSpawnEvent.AllowDespawn event) {
+        public MCEntityLivingSpecialSpawnEvent(LivingSpawnEvent.SpecialSpawn event) {
             super(event);
-            this.event = event;
         }
     
         @Override
-        public void forceDespawn() {
-            event.setResult(Event.Result.ALLOW);
+        public void allow() {
+            event.setCanceled(false);
         }
     
         @Override
-        public void forceRemain() {
-            event.setResult(Event.Result.DENY);
+        public void deny() {
+            event.setCanceled(true);
         }
     
         @Override
         public void pass() {
-            event.setResult(Event.Result.DEFAULT);
         }
     }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCEntityLivingSpawnEvent.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCEntityLivingSpawnEvent.java
@@ -1,0 +1,89 @@
+package crafttweaker.mc1120.events.handling;
+
+import crafttweaker.api.entity.IEntityLivingBase;
+import crafttweaker.api.event.EntityLivingSpawnEvent;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.api.tileentity.IMobSpawnerBaseLogic;
+import crafttweaker.api.world.IWorld;
+import crafttweaker.mc1120.tileentity.MCMobSpawnerBaseLogic;
+import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent {
+    
+    private final LivingSpawnEvent event;
+    
+    public MCEntityLivingSpawnEvent(LivingSpawnEvent event) {
+        this.event = event;
+    }
+    
+    @Override
+    public IWorld getWorld() {
+        return CraftTweakerMC.getIWorld(event.getWorld());
+    }
+    
+    @Override
+    public float getX() {
+        return event.getX();
+    }
+    
+    @Override
+    public float getY() {
+        return event.getY();
+    }
+    
+    @Override
+    public float getZ() {
+        return event.getZ();
+    }
+    
+    @Override
+    public IEntityLivingBase getEntityLivingBase() {
+        return CraftTweakerMC.getIEntityLivingBase(event.getEntityLiving());
+    }
+    
+    public static class MCEntityLivingExtendedSpawnEvent extends MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent.EntityLivingExtendedSpawnEvent {
+    
+        private final IMobSpawnerBaseLogic spawnerBaseLogic;
+        
+        public MCEntityLivingExtendedSpawnEvent(LivingSpawnEvent.CheckSpawn event) {
+            super(event);
+            spawnerBaseLogic = event.getSpawner() == null ? null : new MCMobSpawnerBaseLogic(event.getSpawner());
+        }
+    
+        public MCEntityLivingExtendedSpawnEvent(LivingSpawnEvent.SpecialSpawn event) {
+            super(event);
+            spawnerBaseLogic = event.getSpawner() == null ? null : new MCMobSpawnerBaseLogic(event.getSpawner());
+        }
+    
+        @Override
+        public IMobSpawnerBaseLogic getSpawner() {
+            return spawnerBaseLogic;
+        }
+    }
+    
+    public static class MCEntityLivingAllowDespawnEvent extends MCEntityLivingSpawnEvent implements EntityLivingSpawnEvent.EntityLivingAllowDespawnEvent {
+    
+        private final LivingSpawnEvent.AllowDespawn event;
+    
+        public MCEntityLivingAllowDespawnEvent(LivingSpawnEvent.AllowDespawn event) {
+            super(event);
+            this.event = event;
+        }
+    
+        @Override
+        public void forceDespawn() {
+            event.setResult(Event.Result.ALLOW);
+        }
+    
+        @Override
+        public void forceRemain() {
+            event.setResult(Event.Result.DENY);
+        }
+    
+        @Override
+        public void pass() {
+            event.setResult(Event.Result.DEFAULT);
+        }
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCPlayerAdvancementEvent.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCPlayerAdvancementEvent.java
@@ -1,0 +1,26 @@
+package crafttweaker.mc1120.events.handling;
+
+import crafttweaker.api.event.PlayerAdvancementEvent;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.api.player.IPlayer;
+import net.minecraftforge.event.entity.player.AdvancementEvent;
+
+public class MCPlayerAdvancementEvent implements PlayerAdvancementEvent {
+    
+    private final AdvancementEvent event;
+    
+    public MCPlayerAdvancementEvent(AdvancementEvent event) {
+        this.event = event;
+    }
+    
+    @Override
+    public IPlayer getPlayer() {
+        return CraftTweakerMC.getIPlayer(event.getEntityPlayer());
+    }
+    
+    
+    @Override
+    public String getId() {
+        return event.getAdvancement().getId().toString();
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/VanillaIngredient.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/VanillaIngredient.java
@@ -26,7 +26,7 @@ public class VanillaIngredient extends Ingredient {
     
     @Override
     public ItemStack[] getMatchingStacks() {
-        return ingredient == null ? new ItemStack[0] : CraftTweakerMC.getItemStacks(ingredient.getItemArray());
+        return CraftTweakerMC.getItemStacks(ingredient.getItemArray());
     }
     
     @Override
@@ -54,7 +54,6 @@ public class VanillaIngredient extends Ingredient {
     
     @Override
     protected void invalidate() {
-        this.ingredient = null;
         this.stacks = null;
     }
     

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/VanillaIngredient.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/VanillaIngredient.java
@@ -1,0 +1,74 @@
+package crafttweaker.mc1120.item;
+
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.client.util.RecipeItemHelper;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.NonNullList;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@MethodsReturnNonnullByDefault
+public class VanillaIngredient extends Ingredient {
+    
+    private IIngredient ingredient;
+    private IntList stacks = null;
+    
+    public VanillaIngredient(@Nonnull IIngredient ingredient) {
+        this.ingredient = ingredient;
+    }
+    
+    @Override
+    public ItemStack[] getMatchingStacks() {
+        return ingredient == null ? new ItemStack[0] : CraftTweakerMC.getItemStacks(ingredient.getItemArray());
+    }
+    
+    @Override
+    public boolean apply(@Nullable ItemStack itemStack) {
+        return ingredient.matches(CraftTweakerMC.getIItemStack(itemStack));
+    }
+    
+    @Override
+    public IntList getValidItemStacksPacked() {
+        if(stacks != null) {
+            return stacks;
+        }
+        
+        IntList list = new IntArrayList();
+        if(ingredient != null) {
+            NonNullList<ItemStack> itemStacks = NonNullList.create();
+            for(ItemStack stack : CraftTweakerMC.getItemStacks(ingredient.getItemArray())) {
+                stack.getItem().getSubItems(CreativeTabs.SEARCH, itemStacks);
+            }
+            itemStacks.stream().mapToInt(RecipeItemHelper::pack).forEach(list::add);
+        }
+        
+        return stacks = list;
+    }
+    
+    @Override
+    protected void invalidate() {
+        this.ingredient = null;
+        this.stacks = null;
+    }
+    
+    @Override
+    public boolean isSimple() {
+        return false;
+    }
+    
+    @Override
+    public boolean test(@Nullable ItemStack input) {
+        return apply(input);
+    }
+    
+    public IIngredient getIngredient() {
+        return ingredient;
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/liquid/MCLiquidStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/liquid/MCLiquidStack.java
@@ -9,12 +9,15 @@ import crafttweaker.api.player.IPlayer;
 import crafttweaker.mc1120.data.NBTConverter;
 import crafttweaker.mc1120.item.MCItemStack;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemBucket;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fluids.UniversalBucket;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
 import java.util.Collections;
@@ -216,8 +219,14 @@ public class MCLiquidStack implements ILiquidStack {
         final ItemStack itemStack = CraftTweakerMC.getItemStack(item);
     
         //Hardcoded cause a bucket that's drained with less than 1000 MB returns itself
-        if(itemStack.getItem() instanceof ItemBucket || itemStack.getItem() == Items.MILK_BUCKET)
-            return new MCItemStack(new ItemStack(Items.BUCKET, 1));
+        final Item item1 = itemStack.getItem();
+        if(item1 instanceof ItemBucket
+                || item1 instanceof UniversalBucket
+                || item1 == Items.MILK_BUCKET
+                || item1 == Items.WATER_BUCKET
+                || item1 == Items.LAVA_BUCKET
+                || item1 == ForgeModContainer.getInstance().universalBucket
+        ) return new MCItemStack(new ItemStack(Items.BUCKET, 1));
     
         final IFluidHandlerItem fluidHandler = FluidUtil.getFluidHandler(itemStack);
         if(fluidHandler == null)

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/liquid/MCLiquidStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/liquid/MCLiquidStack.java
@@ -216,7 +216,7 @@ public class MCLiquidStack implements ILiquidStack {
         final ItemStack itemStack = CraftTweakerMC.getItemStack(item);
     
         //Hardcoded cause a bucket that's drained with less than 1000 MB returns itself
-        if(itemStack.getItem().getClass() == ItemBucket.class || itemStack.getItem() == Items.MILK_BUCKET)
+        if(itemStack.getItem() instanceof ItemBucket || itemStack.getItem() == Items.MILK_BUCKET)
             return new MCItemStack(new ItemStack(Items.BUCKET, 1));
     
         final IFluidHandlerItem fluidHandler = FluidUtil.getFluidHandler(itemStack);

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/liquid/MCLiquidStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/liquid/MCLiquidStack.java
@@ -128,18 +128,20 @@ public class MCLiquidStack implements ILiquidStack {
     @Override
     public List<IItemStack> getItems() {
         final IItemStack stack = CraftTweakerMC.getIItemStack(FluidUtil.getFilledBucket(this.stack.copy()));
-        if(stack != null)
-            return Collections.singletonList(stack.withDisplayName(String.format("Any container with %s * %d", this.stack
-                    .getLocalizedName(), this.getAmount())));
+        if(stack != null) {
+            final String name = String.format("Any container with %s * %d", this.stack.getLocalizedName(), this.getAmount());
+            return Collections.singletonList(stack.withDisplayName(name));
+        }
         return Collections.emptyList();
     }
     
     @Override
     public IItemStack[] getItemArray() {
         final IItemStack stack = CraftTweakerMC.getIItemStack(FluidUtil.getFilledBucket(this.stack.copy()));
-        if(stack != null)
-            return new IItemStack[]{stack.withDisplayName(String.format("Any container with %s * %d", this.stack.getLocalizedName(), this
-                    .getAmount()))};
+        if(stack != null) {
+            final String name = String.format("Any container with %s * %d", this.stack.getLocalizedName(), this.getAmount());
+            return new IItemStack[]{stack.withDisplayName(name)};
+        }
         return new IItemStack[0];
     }
 

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
@@ -53,11 +53,9 @@ public class MCOreDictEntry implements IOreDictEntry {
                 //Unfortunately there's no way of getting the oreList from the oreIngredient without Reflection
                 NonNullList<ItemStack> ores = (NonNullList<ItemStack>) MCOreDictEntry.ORE_FIELD.get(oreIngredient);
                 
-                //Reference to OreDictionary#idToStack
-                List<NonNullList<ItemStack>> oreDicts = getOredictContents();
-                for(int oreId = 0; oreId < oreDicts.size(); oreId++) {
-                    if(ores == oreDicts.get(oreId))
-                        return new MCOreDictEntry(OreDictionary.getOreName(oreId));
+                for(String oreName : OreDictionary.getOreNames()) {
+                    if(ores == OreDictionary.getOres(oreName, false))
+                        return new MCOreDictEntry(oreName);
                 }
                 
             } catch(IllegalAccessException e) {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeShaped.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeShaped.java
@@ -93,6 +93,8 @@ public class MCRecipeShaped extends MCRecipeBase implements IShapedRecipe {
     }
 
     private ItemStack getCraftingResult(InventoryCrafting inv, Pair<Integer, Integer> offsetPair, IIngredient[][] ingredients) {
+        if(offsetPair == offsetInvalid)
+            return ItemStack.EMPTY;
         int rowOffset = offsetPair.getKey();
         int columnOffset = offsetPair.getValue();
         if(recipeFunction != null) {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/tileentity/MCMobSpawnerBaseLogic.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/tileentity/MCMobSpawnerBaseLogic.java
@@ -1,0 +1,59 @@
+package crafttweaker.mc1120.tileentity;
+
+import crafttweaker.api.data.IData;
+import crafttweaker.api.entity.IEntityDefinition;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.api.tileentity.IMobSpawnerBaseLogic;
+import crafttweaker.api.world.IBlockPos;
+import crafttweaker.api.world.IWorld;
+import crafttweaker.mc1120.data.NBTConverter;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.MobSpawnerBaseLogic;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+
+public class MCMobSpawnerBaseLogic implements IMobSpawnerBaseLogic {
+    
+    private final MobSpawnerBaseLogic mobSpawnerBaseLogic;
+    
+    public MCMobSpawnerBaseLogic(MobSpawnerBaseLogic mobSpawnerBaseLogic) {
+        this.mobSpawnerBaseLogic = mobSpawnerBaseLogic;
+    }
+    
+    @Override
+    public void setEntityDefinition(IEntityDefinition entityDefinition) {
+        final Object internal = entityDefinition.getInternal();
+        if(internal instanceof EntityEntry) {
+            mobSpawnerBaseLogic.setEntityId(((EntityEntry) internal).delegate.name());
+        }
+    }
+    
+    @Override
+    public void updateSpawner() {
+        mobSpawnerBaseLogic.updateSpawner();
+    }
+    
+    @Override
+    public IData getNbtData() {
+        return NBTConverter.from(mobSpawnerBaseLogic.writeToNBT(new NBTTagCompound()), true);
+    }
+    
+    @Override
+    public void setNbtData(IData nbtData) {
+        mobSpawnerBaseLogic.readFromNBT((NBTTagCompound) NBTConverter.from(nbtData));
+    }
+    
+    @Override
+    public void setDelayToMin() {
+        mobSpawnerBaseLogic.setDelayToMin(1);
+    }
+    
+    @Override
+    public IWorld getWorld() {
+        return CraftTweakerMC.getIWorld(mobSpawnerBaseLogic.getSpawnerWorld());
+    }
+    
+    @Override
+    public IBlockPos getBlockPos() {
+        return CraftTweakerMC.getIBlockPos(mobSpawnerBaseLogic.getSpawnerPosition());
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/MCBiome.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/MCBiome.java
@@ -88,4 +88,8 @@ public class MCBiome implements IBiome {
         }
         return types;
     }
+    
+    public Biome getInternal() {
+        return biome;
+    }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/MCWorld.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/MCWorld.java
@@ -117,6 +117,11 @@ public class MCWorld extends MCBlockAccess implements IWorld {
     }
     
     @Override
+    public IRayTraceResult rayTraceBlocks(IVector3d begin, IVector3d ray, boolean stopOnLiquid, boolean ignoreBlockWithoutBoundingBox, boolean returnLastUncollidableBlock) {
+        return CraftTweakerMC.getIRayTraceResult(this.world.rayTraceBlocks(CraftTweakerMC.getVec3d(begin), CraftTweakerMC.getVec3d(ray), stopOnLiquid, ignoreBlockWithoutBoundingBox, returnLastUncollidableBlock));
+    }
+    
+    @Override
 	public boolean setBlockState(IBlockState state, IBlockPos pos) {
 		return world.setBlockState((BlockPos)pos.getInternal(), (net.minecraft.block.state.IBlockState)state.getInternal());
 	}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/expand/ExpandFacing.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/expand/ExpandFacing.java
@@ -11,11 +11,11 @@ import stanhebben.zenscript.annotations.*;
 public class ExpandFacing {
     
     static final IFacing NORTH = new MCFacing(EnumFacing.NORTH);
-    static final IFacing EAST = new MCFacing(EnumFacing.NORTH);
-    static final IFacing WEST = new MCFacing(EnumFacing.NORTH);
-    static final IFacing SOUTH = new MCFacing(EnumFacing.NORTH);
-    static final IFacing UP = new MCFacing(EnumFacing.NORTH);
-    static final IFacing DOWN = new MCFacing(EnumFacing.NORTH);
+    static final IFacing EAST = new MCFacing(EnumFacing.EAST);
+    static final IFacing WEST = new MCFacing(EnumFacing.WEST);
+    static final IFacing SOUTH = new MCFacing(EnumFacing.SOUTH);
+    static final IFacing UP = new MCFacing(EnumFacing.UP);
+    static final IFacing DOWN = new MCFacing(EnumFacing.DOWN);
     
     @ZenMethodStatic
     public static IFacing north() {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/expand/ExpandVector3d.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/expand/ExpandVector3d.java
@@ -1,0 +1,20 @@
+package crafttweaker.mc1120.world.expand;
+
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.util.Position3f;
+import crafttweaker.api.world.IVector3d;
+import crafttweaker.mc1120.util.MCPosition3f;
+import crafttweaker.mc1120.world.MCVector3d;
+import net.minecraft.util.math.Vec3d;
+import stanhebben.zenscript.annotations.ZenExpansion;
+import stanhebben.zenscript.annotations.ZenMethodStatic;
+
+@ZenExpansion("crafttweaker.world.IVector3d")
+@ZenRegister
+public class ExpandVector3d {
+    
+    @ZenMethodStatic
+    public static IVector3d create(double x, double y, double z) {
+        return new MCVector3d(new Vec3d(x, y, z));
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/expand/ExpandVector3d.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/expand/ExpandVector3d.java
@@ -1,9 +1,7 @@
 package crafttweaker.mc1120.world.expand;
 
 import crafttweaker.annotations.ZenRegister;
-import crafttweaker.api.util.Position3f;
 import crafttweaker.api.world.IVector3d;
-import crafttweaker.mc1120.util.MCPosition3f;
 import crafttweaker.mc1120.world.MCVector3d;
 import net.minecraft.util.math.Vec3d;
 import stanhebben.zenscript.annotations.ZenExpansion;

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/recipeWrappers/BrewingRecipeCWrapper.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/recipeWrappers/BrewingRecipeCWrapper.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import crafttweaker.mc1120.brewing.MultiBrewingRecipe;
 import crafttweaker.mods.jei.JEIAddonPlugin;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.plugins.vanilla.brewing.BrewingRecipeWrapper;
@@ -29,8 +30,8 @@ public class BrewingRecipeCWrapper extends BrewingRecipeWrapper  {
 
 	@Override
 	public void getIngredients(IIngredients ingredients) {
-		ingredients.setInputLists(ItemStack.class, ingredientList);
-		ingredients.setOutput(ItemStack.class, output);
+	    ingredients.setInputLists(VanillaTypes.ITEM, ingredientList);
+		ingredients.setOutput(VanillaTypes.ITEM, output);
 	}
 	
 	@Override

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/recipeWrappers/CraftingRecipeWrapperShaped.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/recipeWrappers/CraftingRecipeWrapperShaped.java
@@ -3,11 +3,14 @@ package crafttweaker.mods.jei.recipeWrappers;
 import crafttweaker.mc1120.recipes.*;
 import crafttweaker.mods.jei.JEIAddonPlugin;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.api.recipe.wrapper.IShapedCraftingRecipeWrapper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
 
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -26,8 +29,8 @@ public class CraftingRecipeWrapperShaped implements IShapedCraftingRecipeWrapper
     
     @Override
     public void getIngredients(IIngredients ingredients) {
-        ingredients.setOutput(ItemStack.class, recipe.getRecipeOutput());
-        ingredients.setInputs(ItemStack.class, recipe.getIngredients().stream().map(Ingredient::getMatchingStacks).map(Arrays::asList).collect(Collectors.toList()));
+        ingredients.setOutput(VanillaTypes.ITEM, recipe.getRecipeOutput());
+        ingredients.setInputLists(VanillaTypes.ITEM, recipe.getIngredients().stream().map(Ingredient::getMatchingStacks).map(Arrays::asList).collect(Collectors.toList()));
     }
     
     @Override
@@ -38,5 +41,11 @@ public class CraftingRecipeWrapperShaped implements IShapedCraftingRecipeWrapper
     @Override
     public int getHeight() {
         return recipe.getRecipeHeight();
+    }
+    
+    @Nullable
+    @Override
+    public ResourceLocation getRegistryName() {
+        return recipe.getRegistryName();
     }
 }

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/recipeWrappers/CraftingRecipeWrapperShapeless.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/recipeWrappers/CraftingRecipeWrapperShapeless.java
@@ -3,11 +3,14 @@ package crafttweaker.mods.jei.recipeWrappers;
 import crafttweaker.mc1120.recipes.*;
 import crafttweaker.mods.jei.JEIAddonPlugin;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import mezz.jei.api.recipe.wrapper.ICraftingRecipeWrapper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
 
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -26,7 +29,13 @@ public class CraftingRecipeWrapperShapeless implements ICraftingRecipeWrapper {
     
     @Override
     public void getIngredients(IIngredients ingredients) {
-        ingredients.setOutput(ItemStack.class, recipe.getRecipeOutput());
-        ingredients.setInputs(ItemStack.class, recipe.getIngredients().stream().map(Ingredient::getMatchingStacks).map(Arrays::asList).collect(Collectors.toList()));
+        ingredients.setOutput(VanillaTypes.ITEM, recipe.getRecipeOutput());
+        ingredients.setInputLists(VanillaTypes.ITEM, recipe.getIngredients().stream().map(Ingredient::getMatchingStacks).map(Arrays::asList).collect(Collectors.toList()));
+    }
+    
+    @Nullable
+    @Override
+    public ResourceLocation getRegistryName() {
+        return recipe.getRegistryName();
     }
 }


### PR DESCRIPTION
closes #677 
closes #707

PlayerAdvancementEvent
EntityLivingSpawnEvents (actually more than one but one type)


```
recipes.addShapeless("liquidRecipe", <minecraft:bedrock>, [<liquid:water> * 100, <minecraft:bedrock>], null, null);
```
Works and will drain the container (or replace it with an empty bucket if it's the vanilla buckets cause they cannot be drained correctly (WIP) should be thoroughly tested (by players)

Added a VanillaIngredient that will be used in CrafttweakerMC.getIngredient(IIngredient) isntead of creating a normal Vanilla Ingredient from the matching stacks