### PR TITLE
Fix #755 Catch and log errors when hiding invalid JEI categories

### DIFF
--- a/CraftTweaker2-MC1120-Mod-JEI/build.gradle
+++ b/CraftTweaker2-MC1120-Mod-JEI/build.gradle
@@ -31,5 +31,5 @@ dependencies {
     compile(project(':ZenScript'))
     compile(project(':CraftTweaker2-API'))
     compile project(':CraftTweaker2-MC1120-Main')
-    deobfCompile "mezz.jei:jei_1.12.2:4.13.1.222"
+    deobfCompile "mezz.jei:jei_1.12.2:4.15.0.271"
 }

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEIAddonPlugin.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEIAddonPlugin.java
@@ -37,7 +37,7 @@ public class JEIAddonPlugin implements IModPlugin {
     public void register(IModRegistry registry) {
         jeiHelpers = registry.getJeiHelpers();
         itemRegistry = registry.getIngredientRegistry();
-        ingredientHelper = itemRegistry.getIngredientHelper(ItemStack.class);
+        ingredientHelper = itemRegistry.getIngredientHelper(VanillaTypes.ITEM);
         modRegistry = registry;
         JEIMod.onRegistered();
         

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEIMod.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEIMod.java
@@ -4,20 +4,20 @@ import crafttweaker.CraftTweakerAPI;
 import crafttweaker.mc1120.commands.*;
 import crafttweaker.mods.jei.commands.ConflictCommand;
 import crafttweaker.mods.jei.recipeWrappers.*;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
+
 import net.minecraft.command.ICommandSender;
-import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.*;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 
 import static crafttweaker.mc1120.commands.SpecialMessagesChat.*;
 import static crafttweaker.mods.jei.JEI.*;
 
-@Mod(modid = "crafttweakerjei", name = "CraftTweaker JEI Support", version = "2.0.2", dependencies = "after:jei;", acceptedMinecraftVersions = "[1.12, 1.13)")
+@Mod(modid = "crafttweakerjei", name = "CraftTweaker JEI Support", version = "2.0.3", dependencies = "after:jei@[4.12.0,);", acceptedMinecraftVersions = "[1.12, 1.13)")
 public class JEIMod {
-    
+
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
         
@@ -63,15 +63,21 @@ public class JEIMod {
             }
             if(JEIAddonPlugin.itemRegistry != null) {
                 if(!JEI.HIDDEN_ITEMS.isEmpty()) {
-                    JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(ItemStack.class, JEI.HIDDEN_ITEMS);
+                    JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(VanillaTypes.ITEM, JEI.HIDDEN_ITEMS);
                 }
                 if(!JEI.HIDDEN_LIQUIDS.isEmpty()) {
-                    JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(FluidStack.class, JEI.HIDDEN_LIQUIDS);
+                    JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(VanillaTypes.FLUID, JEI.HIDDEN_LIQUIDS);
                 }
             }
             if(JEIAddonPlugin.recipeRegistry != null)
                 if(!JEI.HIDDEN_CATEGORIES.isEmpty()) {
-                    JEI.HIDDEN_CATEGORIES.forEach(str -> JEIAddonPlugin.recipeRegistry.hideRecipeCategory(str));
+                    JEI.HIDDEN_CATEGORIES.forEach(str -> {
+                        try {
+                            JEIAddonPlugin.recipeRegistry.hideRecipeCategory(str);
+                        } catch (RuntimeException e) {
+                            CraftTweakerAPI.logError("Failed to hide recipe category: " + str, e);
+                        }
+                    });
                 }
         }
     }

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/actions/AddItemAction.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/actions/AddItemAction.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import crafttweaker.IAction;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.mods.jei.JEIAddonPlugin;
-import net.minecraft.item.ItemStack;
+import mezz.jei.api.ingredients.VanillaTypes;
 
 public class AddItemAction implements IAction{
 
@@ -19,7 +19,7 @@ public class AddItemAction implements IAction{
 	
 	@Override
 	public void apply() {
-		JEIAddonPlugin.itemRegistry.addIngredientsAtRuntime(ItemStack.class, Collections.singletonList(getItemStack(stack)));		
+		JEIAddonPlugin.itemRegistry.addIngredientsAtRuntime(VanillaTypes.ITEM, Collections.singletonList(getItemStack(stack)));
 	}
 
 	@Override

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/actions/HideAction.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/actions/HideAction.java
@@ -8,8 +8,6 @@ import crafttweaker.api.item.IItemStack;
 import crafttweaker.mods.jei.*;
 import net.minecraft.item.ItemStack;
 
-import java.util.*;
-
 public class HideAction implements IAction {
     
     private final IItemStack stack;
@@ -29,8 +27,6 @@ public class HideAction implements IAction {
         
         ItemStack IStack = getItemStack(stack);
         JEI.HIDDEN_ITEMS.addAll(JEIAddonPlugin.getSubTypes(IStack));
-//        JEIAddonPlugin.itemRegistry.removeIngredientsAtRuntime(ItemStack.class, (Collection)JEIAddonPlugin.getSubTypes(IStack));
-
     }
     
     @Override


### PR DESCRIPTION
This updates the JEI dev version and adds a try/catch to removing recipe categories in order to fix #755.