### PR TITLE
Added LogLevel to ILogger:

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/api/logger/FileLogger.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/logger/FileLogger.java
@@ -15,6 +15,7 @@ public class FileLogger implements ILogger {
     private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ISO_LOCAL_TIME;
     
     private final Writer output;
+    private LogLevel logLevel = LogLevel.INFO;
     
     public FileLogger(File logFile) {
         try {
@@ -23,17 +24,30 @@ public class FileLogger implements ILogger {
             throw new RuntimeException("Cannot create log file.", e);
         }
     }
-    
+
+    @Override
+    public void setLogLevel(LogLevel logLevel) {
+        if(logLevel.canLog(LogLevel.INFO))
+            this.logLevel = logLevel;
+    }
+
+    @Override
+    public LogLevel getLogLevel() {
+        return logLevel;
+    }
+
     @Override
     public void log(LogLevel level, String message, boolean prefix) {
-        try {
-            if(prefix) {
-                message = String.format("[%s][%s][%s][%s] %s", TIME_FORMAT.format(LocalDateTime.now()), ModLoadingContext.get().getActiveContainer().getCurrentState(), EffectiveSide.get(), level, strip(message));
+        if(this.logLevel.canLog(level)) {
+            try {
+                if(prefix) {
+                    message = String.format("[%s][%s][%s][%s] %s", TIME_FORMAT.format(LocalDateTime.now()), ModLoadingContext.get().getActiveContainer().getCurrentState(), EffectiveSide.get(), level, strip(message));
+                }
+                this.output.write(message + "\n");
+                this.output.flush();
+            } catch(IOException e) {
+                e.printStackTrace();
             }
-            this.output.write(message + "\n");
-            this.output.flush();
-        } catch(IOException e) {
-            e.printStackTrace();
         }
         
     }

--- a/src/main/java/com/blamejared/crafttweaker/api/logger/GroupLogger.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/logger/GroupLogger.java
@@ -14,7 +14,19 @@ public class GroupLogger implements ILogger {
     public List<ILogger> getSubLoggers() {
         return subLoggers;
     }
-    
+
+    @Override
+    public void setLogLevel(LogLevel logLevel) {
+        for (ILogger subLogger : subLoggers) {
+            subLogger.setLogLevel(logLevel);
+        }
+    }
+
+    @Override
+    public LogLevel getLogLevel() {
+        return subLoggers.stream().map(ILogger::getLogLevel).min(LogLevel::compareTo).orElse(LogLevel.DEBUG);
+    }
+
     @Override
     public void log(LogLevel level, String message, boolean prefix) {
         for(ILogger logger : getSubLoggers()) {

--- a/src/main/java/com/blamejared/crafttweaker/api/logger/ILogger.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/logger/ILogger.java
@@ -11,6 +11,32 @@ import java.io.*;
 @ZenRegister
 @ZenCodeType.Name("crafttweaker.api.ILogger")
 public interface ILogger {
+
+    /**
+     * <p>
+     * Sets the last level that will be logged<br>
+     * E.g. a logLevel of INFO means that everything below
+     *   it (in this case{@code [DEBUG]}) will <strong>not</strong> be logged
+     * </p>
+     * <p>
+     * In case of using SubLoggers (e.g. {@link GroupLogger}) propagates the
+     *   method call to <strong>all</strong> SubLoggers
+     * </p>
+     */
+    void setLogLevel(LogLevel logLevel);
+
+    /**
+     * <p>
+     * Returns the last level that will be logged<br>
+     * E.g. a logLevel of INFO means that everything below
+     *   it (in this case{@code [DEBUG]}) will <strong>not</strong> be logged
+     * </p>
+     * <p>
+     * In case of using SubLoggers (e.g. {@link GroupLogger}) returns the last level
+     *   at which <strong>anything</strong> will be logged
+     * </p>
+     */
+    LogLevel getLogLevel();
     
     void log(LogLevel level, String message, boolean prefix);
     

--- a/src/main/java/com/blamejared/crafttweaker/api/logger/LogLevel.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/logger/LogLevel.java
@@ -1,6 +1,23 @@
 package com.blamejared.crafttweaker.api.logger;
 
+import java.util.Arrays;
+
 public enum LogLevel {
     
     DEBUG, INFO, WARNING, ERROR;
+
+    public boolean canLog(LogLevel other) {
+        return this.compareTo(other) <= 0;
+    }
+
+    /**
+     * The maximum character length of any enum name
+     * Used to make print formats easier
+     */
+    public static final int MAX_LENGTH = Arrays.stream(LogLevel.values())
+            .map(Enum::name)
+            .mapToInt(String::length)
+            .max()
+            .orElse(7);
+
 }


### PR DESCRIPTION
Setting an ILogger's Loglevel restricts it in which logs he will be able to print.
Setting it to DEBUG will print everything, whereas to ERROR will onyl print errors.

FileLoggers by default are on INFO, and cannot go to less than that (i.e. WARNING and ERROR)