### PR TITLE
Removed unused code from the food command. Closes #834

### DIFF
--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/Commands.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/commands/Commands.java
@@ -67,8 +67,6 @@ public class Commands {
             
             @Override
             public void executeCommand(MinecraftServer server, ICommandSender sender, String[] args) {
-                List<ILiquidDefinition> liquids = CraftTweakerAPI.game.getLiquids();
-                liquids.sort(LIQUID_COMPARATOR);
                 
                 CraftTweakerAPI.logCommand("Foods:");
                 for(IItemDefinition item : CraftTweakerAPI.game.getItems()) {


### PR DESCRIPTION
This removes the unused liquid code. I didn't add a comparator to the food items to preserve the current behaviour. 