### PR TITLE
Internal accessor for Minecraft block state in IBlockState.

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockState.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/block/IBlockState.java
@@ -43,4 +43,6 @@ public interface IBlockState extends IBlockProperties, IBlockStateMatcher {
     
     @ZenMethod
     IBlockStateMatcher matchBlock();
+
+    Object getInternal();
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCBlockState.java
@@ -194,4 +194,9 @@ public class MCBlockState extends MCBlockProperties implements crafttweaker.api.
     public String toCommandString() {
         return toString();
     }
+
+    @Override
+    public Object getInternal() {
+        return blockState;
+    }
 }


### PR DESCRIPTION
There currently isn't an internal accessor for IBlockState, meaning that using it within your own code or your own classes locks you into that implementation unless you resort to some form of trickery in order to get it to function. :(