### PR TITLE
Implement an "isItemBlock" functionality for IItemStacks.

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemStack.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemStack.java
@@ -49,7 +49,10 @@ public interface IItemStack extends IIngredient {
      * @return Whether or not the item linked to this stack is an itemblock.
      */
     @ZenGetter("isItemBlock")
-    boolean isItemBlock();
+    default boolean isItemBlock() {
+        CraftTweakerAPI.logError("Class " + this.getClass().getCanonicalName() + " doesns't override IItemStack::isItemBlock!");
+        return false;
+    }
     
     /**
      * Gets the unlocalized item name.

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemStack.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemStack.java
@@ -50,7 +50,7 @@ public interface IItemStack extends IIngredient {
      */
     @ZenGetter("isItemBlock")
     default boolean isItemBlock() {
-        CraftTweakerAPI.logError("Class " + this.getClass().getCanonicalName() + " doesns't override IItemStack::isItemBlock!");
+        CraftTweakerAPI.logError("Class " + this.getClass().getCanonicalName() + " doesn't override IItemStack::isItemBlock!");
         return false;
     }
     

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemStack.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/IItemStack.java
@@ -42,6 +42,14 @@ public interface IItemStack extends IIngredient {
      */
     @ZenGetter("definition")
     IItemDefinition getDefinition();
+
+    /**
+     * Determine if the itemstack contains an itemblock.
+     *
+     * @return Whether or not the item linked to this stack is an itemblock.
+     */
+    @ZenGetter("isItemBlock")
+    boolean isItemBlock();
     
     /**
      * Gets the unlocalized item name.

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/item/ItemStackUnknown.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/item/ItemStackUnknown.java
@@ -23,6 +23,11 @@ public final class ItemStackUnknown implements IItemStack {
     }
 
     @Override
+    public boolean isItemBlock() {
+        throw new IllegalStateException("ItemStackUnknown is only supposed to be used internally!");
+    }
+
+    @Override
     public String getName() {
         throw new IllegalStateException("ItemStackUnknown is only supposed to be used internally!");
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
@@ -109,10 +109,6 @@ public class MCItemStack implements IItemStack {
 
     @Override
     public boolean isItemBlock() {
-        if (stack.isEmpty()) {
-            return false;
-        }
-
         return stack.getItem() instanceof ItemBlock;
     }
 

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
@@ -106,7 +106,16 @@ public class MCItemStack implements IItemStack {
     public IItemDefinition getDefinition() {
         return new MCItemDefinition(stack.getItem().getRegistryName().toString(), stack.getItem());
     }
-    
+
+    @Override
+    public boolean isItemBlock() {
+        if (stack.isEmpty()) {
+            return false;
+        }
+
+        return stack.getItem() instanceof ItemBlock;
+    }
+
     @Override
     public String getName() {
         return stack.getUnlocalizedName();


### PR DESCRIPTION
Simple boolean function to determine if an arbitrary itemstack's contained item is an itemblock:

```
[INITIALIZATION][CLIENT][INFO] dirt is an item block: true
[INITIALIZATION][CLIENT][INFO] sticks are not an item block: false
```

Test script:

```zenscript
print("dirt is an item block: " ~ <minecraft:dirt>.isItemBlock);
print("sticks are not an item block: " ~ <minecraft:stick>.isItemBlock);
```