### PR TITLE
Make right-click-block-event properly cancellable.

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/PlayerRightClickBlockEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/PlayerRightClickBlockEvent.java
@@ -8,7 +8,7 @@ import stanhebben.zenscript.annotations.ZenSetter;
 
 @ZenClass("crafttweaker.event.PlayerInteractBlockEvent")
 @ZenRegister
-public interface PlayerRightClickBlockEvent extends PlayerInteractEvent, IHasCancellationResult {
+public interface PlayerRightClickBlockEvent extends PlayerInteractEvent, IHasCancellationResult, IEventCancelable {
 
     @ZenGetter("hitVector")
     IVector3d getHitVector();

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCPlayerRightClickBlockEvent.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCPlayerRightClickBlockEvent.java
@@ -51,5 +51,13 @@ public class MCPlayerRightClickBlockEvent extends MCPlayerInteractEvent implemen
         event.setCancellationResult(EnumActionResult.valueOf(value));
     }
 
+    @Override
+    public boolean isCanceled() {
+        return event.isCanceled();
+    }
 
+    @Override
+    public void setCanceled(boolean canceled) {
+        event.setCanceled(canceled);
+    }
 }


### PR DESCRIPTION
Complex story: RightClickEmpty wasn't cancellable, so I removed the default cancellable implementation from the PlayerInteractEvent and *thought* I had implemented it in all of the subclasses.

RightClickEmpty, I then realised, was only fired on the client, so I deleted it.

This left the situation where RightClickBlock wasn't marked nor implemented IEventCancellable, but also the situation where every player interact event that's implemented is cancellable. However, in the interests of disambiguation, I've left things as-is and implemented it in RightClickBlock.

I never discussed what specifically to do with LeftClickEmpty/RightClickEmpty events.