### PR TITLE
[1.16] Throw an error if a wiki entry is about to be created for a type without Document annotation

### DIFF
--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/CrafttweakerDocumentationPage.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/CrafttweakerDocumentationPage.java
@@ -27,9 +27,9 @@ public abstract class CrafttweakerDocumentationPage {
 
         final CrafttweakerDocumentationPage documentationPage;
         if (element.getAnnotation(ZenCodeType.Name.class) != null) {
-            documentationPage = DocumentedClass.convertClass(element, environment);
+            documentationPage = DocumentedClass.convertClass(element, environment, false);
         } else if (element.getAnnotation(ZenCodeType.Expansion.class) != null) {
-            documentationPage = DocumentedExpansion.convertExpansion(element, environment);
+            documentationPage = DocumentedExpansion.convertExpansion(element, environment, false);
         } else {
             environment.getMessager()
                     .printMessage(Diagnostic.Kind.ERROR, "@Documented requires either @Expansion or @Name to be set as well!", element);

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/documented_class/DocumentedClass.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/documented_class/DocumentedClass.java
@@ -50,11 +50,11 @@ public class DocumentedClass extends CrafttweakerDocumentationPage {
         this.isFunctionalInterface = isFunctionalInterface;
     }
     
-    public static DocumentedClass convertClass(TypeMirror type, ProcessingEnvironment environment) {
-        return convertClass((TypeElement) environment.getTypeUtils().asElement(type), environment);
+    public static DocumentedClass convertClass(TypeMirror type, ProcessingEnvironment environment, boolean forComment) {
+        return convertClass((TypeElement) environment.getTypeUtils().asElement(type), environment, forComment);
     }
     
-    public static DocumentedClass convertClass(TypeElement element, ProcessingEnvironment environment) {
+    public static DocumentedClass convertClass(TypeElement element, ProcessingEnvironment environment, boolean forComment) {
         if(element == null || element.equals(environment.getElementUtils()
                 .getTypeElement("java.lang.Object"))) {
             return null;
@@ -72,12 +72,12 @@ public class DocumentedClass extends CrafttweakerDocumentationPage {
         final ZenCodeType.Name nameAnnotation = element.getAnnotation(ZenCodeType.Name.class);
         final String zsName = nameAnnotation != null ? nameAnnotation.value() : element.getQualifiedName()
                 .toString();
-        final String docPath = IDontKnowHowToNameThisUtil.getDocPath(element);
+        final String docPath = IDontKnowHowToNameThisUtil.getDocPath(element, environment, forComment);
         if(docPath == null) {
             return null;
         }
         
-        final DocumentedClass superClass = convertClass(element.getSuperclass(), environment);
+        final DocumentedClass superClass = convertClass(element.getSuperclass(), environment, forComment);
         //final String docComment = environment.getElementUtils().getDocComment(element);
         
         final String declaringModId = DocumentProcessorNew.getModIdForPackage(element, environment);
@@ -99,7 +99,7 @@ public class DocumentedClass extends CrafttweakerDocumentationPage {
         typesByZSName.put(zsName, element);
         
         if(!(element.getSuperclass() instanceof NoType)) {
-            final DocumentedClass documentedClass = convertClass(element.getSuperclass(), environment);
+            final DocumentedClass documentedClass = convertClass(element.getSuperclass(), environment, forComment);
             if(documentedClass != null) {
                 out.implementedInterfaces.add(documentedClass);
                 out.implementedInterfaces.addAll(documentedClass.implementedInterfaces);
@@ -107,7 +107,7 @@ public class DocumentedClass extends CrafttweakerDocumentationPage {
         }
         
         for(final TypeMirror anInterface : element.getInterfaces()) {
-            final DocumentedClass documentedClass = convertClass(anInterface, environment);
+            final DocumentedClass documentedClass = convertClass(anInterface, environment, forComment);
             if(documentedClass != null) {
                 out.implementedInterfaces.add(documentedClass);
                 out.implementedInterfaces.addAll(documentedClass.implementedInterfaces);

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/documented_expansion/DocumentedExpansion.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/documented_expansion/DocumentedExpansion.java
@@ -37,7 +37,7 @@ public class DocumentedExpansion extends CrafttweakerDocumentationPage {
         this.declaringModId = declaringModId;
     }
 
-    public static DocumentedExpansion convertExpansion(TypeElement element, ProcessingEnvironment environment) {
+    public static DocumentedExpansion convertExpansion(TypeElement element, ProcessingEnvironment environment, boolean forComment) {
         if (knownTypes.containsKey(element.toString())) {
             final CrafttweakerDocumentationPage documentationPage = knownTypes.get(element.toString());
             if (!(documentationPage instanceof DocumentedExpansion)) {
@@ -62,7 +62,7 @@ public class DocumentedExpansion extends CrafttweakerDocumentationPage {
             return null;
         }
 
-        final String docPath = IDontKnowHowToNameThisUtil.getDocPath(element);
+        final String docPath = IDontKnowHowToNameThisUtil.getDocPath(element, environment, forComment);
         if (docPath == null) {
             return null;
         }
@@ -84,7 +84,7 @@ public class DocumentedExpansion extends CrafttweakerDocumentationPage {
 
     private static DocumentedType findExpandedType(TypeElement element, ZenCodeType.Expansion expansionAnnotation, ProcessingEnvironment environment) {
         if (typesByZSName.containsKey(expansionAnnotation.value())) {
-            return DocumentedType.fromElement(typesByZSName.get(expansionAnnotation.value()), environment);
+            return DocumentedType.fromElement(typesByZSName.get(expansionAnnotation.value()), environment, false);
         }
 
         for (Element enclosedElement : element.getEnclosedElements()) {
@@ -95,7 +95,7 @@ public class DocumentedExpansion extends CrafttweakerDocumentationPage {
                 }
 
                 final VariableElement variableElement = executableElement.getParameters().get(0);
-                final DocumentedType type = DocumentedType.fromElement(variableElement, environment);
+                final DocumentedType type = DocumentedType.fromElement(variableElement, environment, false);
                 if (type != null) {
                     if (!type.getZSName().equals(expansionAnnotation.value())) {
                         environment.getMessager()

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedCaster.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedCaster.java
@@ -55,7 +55,7 @@ public class DocumentedCaster {
             return null;
         }
 
-        return new DocumentedCaster(DocumentedType.fromTypeMirror(element.getReturnType(), environment), caster.implicit());
+        return new DocumentedCaster(DocumentedType.fromTypeMirror(element.getReturnType(), environment, false), caster.implicit());
     }
 
     public static void printCasters(Collection<DocumentedCaster> casters, PrintWriter writer) {

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedMethod.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedMethod.java
@@ -91,7 +91,7 @@ public class DocumentedMethod implements Writable {
         }
         
         final DocumentedType returnType = method.getReturnType()
-                .getKind() == TypeKind.VOID ? null : DocumentedType.fromTypeMirror(method.getReturnType(), environment);
+                .getKind() == TypeKind.VOID ? null : DocumentedType.fromTypeMirror(method.getReturnType(), environment, false);
     
         final AnnotationMirror mirror = AnnotationMirrorUtil.getMirror(method, bracketHandlerAnnotation);
         final String bracketHandlerName = mirror == null ? null : AnnotationMirrorUtil.getAnnotationValue(mirror, "value");

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedParameter.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedParameter.java
@@ -45,7 +45,7 @@ public class DocumentedParameter {
             return null;
         }
 
-        final DocumentedType type = DocumentedType.fromElement(element, environment);
+        final DocumentedType type = DocumentedType.fromElement(element, environment, false);
         final String aDefault = getDefault(element);
         final boolean optional = aDefault != null;
         final String name = element.getSimpleName().toString();

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedProperty.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedProperty.java
@@ -89,7 +89,7 @@ public class DocumentedProperty {
             name = field.getSimpleName().toString();
         }
         
-        final DocumentedType type = DocumentedType.fromTypeMirror(field.asType(), environment);
+        final DocumentedType type = DocumentedType.fromTypeMirror(field.asType(), environment, false);
         return new DocumentedProperty(containingClass, name, true, true, type);
     }
     
@@ -151,7 +151,7 @@ public class DocumentedProperty {
                     .printMessage(Diagnostic.Kind.ERROR, "Getter methods may not return void!", method);
         }
         
-        DocumentedType type = DocumentedType.fromTypeMirror(method.getReturnType(), environment);
+        DocumentedType type = DocumentedType.fromTypeMirror(method.getReturnType(), environment, false);
         return new DocumentedProperty(containingClass, name, true, false, type);
     }
     
@@ -180,7 +180,7 @@ public class DocumentedProperty {
         }
         
         DocumentedType type = DocumentedType.fromElement(method.getParameters()
-                .get(isExpansion ? 1 : 0), environment);
+                .get(isExpansion ? 1 : 0), environment, false);
         return new DocumentedProperty(containingClass, name, false, true, type);
     }
     

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedTypeParameter.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/members/DocumentedTypeParameter.java
@@ -47,7 +47,7 @@ public class DocumentedTypeParameter {
         final String[] examples = CommentUtils.findAllAnnotation(environment.getElementUtils()
                 .getDocComment(method), "@docParam " + name);
         for(TypeMirror bound : typeParameter.getBounds()) {
-            documentedBounds.add(DocumentedType.fromTypeMirror(bound, environment));
+            documentedBounds.add(DocumentedType.fromTypeMirror(bound, environment, false));
         }
         return new DocumentedTypeParameter(documentedBounds, name, examples);
     }

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/util/CommentUtils.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/util/CommentUtils.java
@@ -102,13 +102,13 @@ public class CommentUtils {
         }
         
         if(type.isEmpty()) {
-            return DocumentedType.fromElement(documentedElement.getEnclosingElement(), environment);
+            return DocumentedType.fromElement(documentedElement.getEnclosingElement(), environment, true);
         }
         
         {
             TypeElement typeElement = environment.getElementUtils().getTypeElement(type);
             if(typeElement != null) {
-                final DocumentedType documentedType = DocumentedType.fromElement(typeElement, environment);
+                final DocumentedType documentedType = DocumentedType.fromElement(typeElement, environment, true);
                 if(documentedType != null) {
                     return documentedType;
                 }
@@ -119,7 +119,7 @@ public class CommentUtils {
                 .getPackageOf(documentedElement);
         for(Element enclosedElement : packageOf.getEnclosedElements()) {
             if(enclosedElement.getSimpleName().contentEquals(type)) {
-                final DocumentedType documentedType = DocumentedType.fromElement(enclosedElement, environment);
+                final DocumentedType documentedType = DocumentedType.fromElement(enclosedElement, environment, true);
                 if(documentedType != null) {
                     return documentedType;
                 }
@@ -143,7 +143,7 @@ public class CommentUtils {
                         .map(environment.getElementUtils()::getTypeElement)
                         .filter(Objects::nonNull) //not sure just in case
                         .filter(e -> e.getSimpleName().contentEquals(type))
-                        .map(e -> DocumentedType.fromElement(e, environment))
+                        .map(e -> DocumentedType.fromElement(e, environment, true))
                         .filter(Objects::nonNull)
                         .findAny();
                 if(any.isPresent()) {

--- a/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/util/IDontKnowHowToNameThisUtil.java
+++ b/Crafttweaker_Annotation_Processors/src/main/java/com/blamejared/crafttweaker_annotation_processors/processors/document/shared/util/IDontKnowHowToNameThisUtil.java
@@ -1,38 +1,66 @@
 package com.blamejared.crafttweaker_annotation_processors.processors.document.shared.util;
 
-import com.blamejared.crafttweaker_annotations.annotations.Document;
-import org.openzen.zencode.java.ZenCodeType;
+import com.blamejared.crafttweaker_annotation_processors.processors.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import org.openzen.zencode.java.*;
 
-import javax.lang.model.element.TypeElement;
+import javax.annotation.processing.*;
+import javax.lang.model.element.*;
+import javax.tools.*;
+import java.util.*;
 
 public class IDontKnowHowToNameThisUtil {
+    
+    /**
+     * Suppress the "Custom Type without ZenAnnotation used" error for types starting with this name
+     */
+    private static final Set<String> internalClassNamePrefixes = new HashSet<>();
+    
+    static {
+        internalClassNamePrefixes.add("java.lang");
+        internalClassNamePrefixes.add("java.util");
+        internalClassNamePrefixes.add("org.openzen");
+    }
+    
     private IDontKnowHowToNameThisUtil() {
     }
-
-
-    public static String getDocPath(TypeElement element) {
+    
+    
+    /**
+     * Returns the path where the documentation md file for this type lies.
+     * Logs an error if that type as no ZC Annotations, unless annotated with forComment
+     *
+     * @param forComment Is this lookup only to resolve a {@code {@link }} then errors will eb suppressed
+     * @return The docPath, or {@code null}
+     */
+    public static String getDocPath(TypeElement element, ProcessingEnvironment environment, boolean forComment) {
         final Document document = element.getAnnotation(Document.class);
-        final ZenCodeType.Name nameAnnotation = element.getAnnotation(ZenCodeType.Name.class);
-        final ZenCodeType.Expansion expansionAnnotation = element.getAnnotation(ZenCodeType.Expansion.class);
-
-
-        if (document != null && !document.value().isEmpty()) {
-            return document.value();
+        final Messager messager = environment.getMessager();
+        
+        if(document == null) {
+            if(forComment) {
+                return null;
+            }
+            
+            if(element.getAnnotation(ZenCodeType.Name.class) != null || element.getAnnotation(ZenCodeType.Expansion.class) != null) {
+                messager.printMessage(Diagnostic.Kind.ERROR, "ZenType/Expansion without a Document annotation!", element);
+            } else if(!isInternalClass(element)) {
+                messager.printMessage(Diagnostic.Kind.ERROR, "Custom Type without Zen annotations used! " + element
+                        .getQualifiedName(), element);
+            }
+            return null;
         }
-
-        if (nameAnnotation != null) {
-            return nameAnnotation.value().replace('.', '/');
+        
+        if(document.value().isEmpty()) {
+            final AnnotationMirror mirror = AnnotationMirrorUtil.getMirror(element, Document.class);
+            messager.printMessage(Diagnostic.Kind.ERROR, "Empty Doc Path provided!", element, mirror);
         }
-
-        if (expansionAnnotation != null) {
-            //Expand("x.y.Z") => "x/y/ExpandZ" file
-            final String value = expansionAnnotation.value();
-            final int lastIndex = value.lastIndexOf('.');
-            final String substring = value.substring(lastIndex);
-            return (value.substring(0, lastIndex) + "Expand" + substring).replace('.', '/');
-        }
-
-        return null;
+        return document.value();
     }
-
+    
+    private static boolean isInternalClass(TypeElement element) {
+        final String qualifiedName = element.getQualifiedName().toString();
+        return internalClassNamePrefixes.stream().anyMatch(qualifiedName::startsWith);
+    }
+    
 }

--- a/src/main/java/com/blamejared/crafttweaker/api/events/IEvent.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/events/IEvent.java
@@ -1,12 +1,14 @@
 package com.blamejared.crafttweaker.api.events;
 
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker_annotations.annotations.*;
 import net.minecraftforge.eventbus.api.Event;
 import org.openzen.zencode.java.ZenCodeType;
 
 import java.util.function.Consumer;
 
-@ZenRegister()
+@ZenRegister
+@Document("vanilla/api/event/IEvent")
 @ZenCodeType.Name("crafttweaker.api.event.IEvent")
 public abstract class IEvent<E extends IEvent<E, V>, V extends Event> {
     

--- a/src/main/java/com/blamejared/crafttweaker/api/item/IItemStack.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/item/IItemStack.java
@@ -405,6 +405,11 @@ public interface IItemStack extends IIngredient {
         return new MCWeightedItemStack(this, weight);
     }
     
+    @ZenCodeType.Caster(implicit = true)
+    default MCWeightedItemStack asWeightedItemStack() {
+        return weight(1.0D);
+    }
+    
     @ZenCodeType.Method
     IItemStack mutable();
     

--- a/src/main/java/com/blamejared/crafttweaker/api/item/tooltip/ITooltipFunction.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/item/tooltip/ITooltipFunction.java
@@ -3,13 +3,15 @@ package com.blamejared.crafttweaker.api.item.tooltip;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.impl.util.text.MCTextComponent;
+import com.blamejared.crafttweaker_annotations.annotations.*;
 import org.openzen.zencode.java.ZenCodeType;
 
 import java.util.List;
 
-@FunctionalInterface
-@ZenCodeType.Name("crafttweaker.api.item.tooltip.ITooltipFunction")
 @ZenRegister
+@FunctionalInterface
+@Document("vanilla/api/items/ITooltipFunction")
+@ZenCodeType.Name("crafttweaker.api.item.tooltip.ITooltipFunction")
 public interface ITooltipFunction {
     
     @ZenCodeType.Method

--- a/src/main/java/com/blamejared/crafttweaker/api/managers/IRecipeManager.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/managers/IRecipeManager.java
@@ -85,6 +85,11 @@ public interface IRecipeManager extends CommandStringDisplayable {
         return getRecipes().values().stream().filter(iRecipe -> output.matches(new MCItemStackMutable(iRecipe.getRecipeOutput()))).map(WrapperRecipe::new).collect(Collectors.toList());
     }
     
+    @ZenCodeType.Method
+    default List<WrapperRecipe> getAllRecipes() {
+        return getRecipes().values().stream().map(WrapperRecipe::new).collect(Collectors.toList());
+    }
+    
     /**
      * Remove a recipe based on it's output.
      *

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/CustomCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/CustomCommands.java
@@ -4,7 +4,6 @@ import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.*;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.minecraft.command.CommandSource;

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/MCCommandDispatcher.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/MCCommandDispatcher.java
@@ -3,7 +3,6 @@ package com.blamejared.crafttweaker.impl.commands.custom;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker_annotations.annotations.*;
 import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.StringReader;
 import net.minecraft.command.CommandSource;
 import org.openzen.zencode.java.ZenCodeType;
 
@@ -42,22 +41,12 @@ public class MCCommandDispatcher {
     }
     
     @ZenCodeType.Method
-    public int execute(final StringReader input, final MCCommandSource source) throws Exception {
-        return internal.execute(input, source.getInternal());
-    }
-    
-    @ZenCodeType.Method
     public int execute(final MCParseResults parse) throws Exception {
         return internal.execute(parse.getInternal());
     }
     
     @ZenCodeType.Method
     public MCParseResults parse(final String command, final MCCommandSource source) {
-        return new MCParseResults(internal.parse(command, source.getInternal()));
-    }
-    
-    @ZenCodeType.Method
-    public MCParseResults parse(final StringReader command, final MCCommandSource source) {
         return new MCParseResults(internal.parse(command, source.getInternal()));
     }
     

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/MCCommandNode.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/MCCommandNode.java
@@ -43,83 +43,92 @@ public class MCCommandNode {
         return internal;
     }
     
+    @ZenCodeType.Method
     public MCCommand getCommand() {
         return new MCCommand(internal.getCommand());
     }
     
+    @ZenCodeType.Method
     public Collection<MCCommandNode> getChildren() {
         return internal.getChildren().stream().map(MCCommandNode::new).collect(Collectors.toList());
     }
     
+    @ZenCodeType.Method
     public MCCommandNode getChild(final String name) {
         return MCCommandNode.convert(internal.getChild(name));
     }
     
+    @ZenCodeType.Method
     public MCCommandNode getRedirect() {
         return MCCommandNode.convert(internal.getRedirect());
     }
     
+    @ZenCodeType.Method
     public MCRedirectModifier getRedirectModifier() {
         return new MCRedirectModifier(internal.getRedirectModifier());
     }
     
+    @ZenCodeType.Method
     public boolean canUse(final MCCommandSource source) {
         return internal.canUse(source.getInternal());
     }
     
+    @ZenCodeType.Method
     public void addChild(final MCCommandNode node) {
         internal.addChild(node.internal);
     }
     
+    @ZenCodeType.Method
     public void findAmbiguities(final MCAmbiguityConsumer consumer) {
         internal.findAmbiguities((parent, child, sibling, inputs) -> consumer.ambiguous(MCCommandNode.convert(parent), MCCommandNode.convert(child), MCCommandNode.convert(sibling), inputs));
     }
     
+    @ZenCodeType.Method
     public Predicate<MCCommandSource> getRequirement() {
         return mcCommandSource -> internal.getRequirement().test(mcCommandSource.getInternal());
     }
     
+    @ZenCodeType.Method
     public String getName() {
         return internal.getName();
     }
     
+    @ZenCodeType.Method
     public String getUsageText() {
         return internal.getUsageText();
     }
     
+    @ZenCodeType.Method
     public void parse(String input, MCCommandContextBuilder contextBuilder) throws Exception {
-        parse(new StringReader(input), contextBuilder);
+        internal.parse(new StringReader(input), contextBuilder.getInternal());
     }
     
-    public void parse(StringReader reader, MCCommandContextBuilder contextBuilder) throws Exception {
-        internal.parse(reader, contextBuilder.getInternal());
-    }
-    
+    @ZenCodeType.Method
     public MCSuggestions listSuggestions(MCCommandContext context, MCSuggestionsBuilder builder) throws Exception {
         return new MCSuggestions(internal.listSuggestions(context.getInternal(), builder.getInternal()));
     }
     
+    @ZenCodeType.Method
     public MCArgumentBuilder createBuilder() {
         return MCArgumentBuilder.convert(internal.createBuilder());
     }
     
-    
+    @ZenCodeType.Method
     public Collection<MCCommandNode> getRelevantNodes(final String input) {
-        return getRelevantNodes(new StringReader(input));
+        return internal.getRelevantNodes(new StringReader(input)).stream().map(MCCommandNode::new).collect(Collectors.toList());
     }
     
-    public Collection<MCCommandNode> getRelevantNodes(final StringReader input) {
-        return internal.getRelevantNodes(input).stream().map(MCCommandNode::new).collect(Collectors.toList());
-    }
-    
+    @ZenCodeType.Operator(ZenCodeType.OperatorType.COMPARE)
     public int compareTo(final MCCommandNode o) {
         return this.internal.compareTo(o.internal);
     }
     
+    @ZenCodeType.Method
     public boolean isFork() {
         return internal.isFork();
     }
     
+    @ZenCodeType.Method
     public Collection<String> getExamples() {
         return internal.getExamples();
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/MCStringRange.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/MCStringRange.java
@@ -36,7 +36,7 @@ public class MCStringRange {
     
     @ZenCodeType.Method
     public boolean equals(Object o) {
-        return internal.equals((o));
+        return o instanceof MCStringRange && internal.equals(((MCStringRange) o).internal);
     }
     
     

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/MCSuggestions.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/custom/MCSuggestions.java
@@ -2,7 +2,6 @@ package com.blamejared.crafttweaker.impl.commands.custom;
 
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker_annotations.annotations.*;
-import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.Suggestions;
 import org.openzen.zencode.java.ZenCodeType;
 
@@ -52,8 +51,8 @@ public class MCSuggestions {
     }
     
     @ZenCodeType.Method
-    public List<Suggestion> getList() {
-        return internal.getList();
+    public List<MCSuggestion> getList() {
+        return internal.getList().stream().map(MCSuggestion::new).collect(Collectors.toList());
     }
     
     @ZenCodeType.Method

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/wrappers/WrapperRecipe.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/wrappers/WrapperRecipe.java
@@ -4,6 +4,7 @@ import com.blamejared.crafttweaker.api.annotations.*;
 import com.blamejared.crafttweaker.api.item.*;
 import com.blamejared.crafttweaker.impl.item.*;
 import com.blamejared.crafttweaker.impl.util.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
 import net.minecraft.item.crafting.IRecipe;
 import org.openzen.zencode.java.ZenCodeType;
 
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @ZenRegister
+@Document("vanilla/api/recipe/WrapperRecipe")
 @ZenCodeType.Name("crafttweaker.api.recipes.WrapperRecipe")
 public class WrapperRecipe {
     

--- a/src/main/java/com/blamejared/crafttweaker/impl/util/MCBlockPos.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/util/MCBlockPos.java
@@ -14,9 +14,9 @@ import org.openzen.zencode.java.ZenCodeType;
 @ZenRegister
 @ZenCodeType.Name("crafttweaker.api.util.BlockPos")
 @Document("vanilla/api/util/BlockPos")
-@ZenWrapper(wrappedClass = "net.minecraft.util.math.BlockPos", conversionMethodFormat = "%s.getInternal()", displayStringFormat = "%s.getInternal.toString()")
+@ZenWrapper(wrappedClass = "net.minecraft.util.math.BlockPos", displayStringFormat = "%s.getInternal.toString()")
 public class MCBlockPos {
-    private BlockPos internal;
+    private final BlockPos internal;
 
     public MCBlockPos(BlockPos internal) {
         this.internal = internal;
@@ -80,7 +80,7 @@ public class MCBlockPos {
     @ZenCodeType.Method
     @ZenCodeType.Operator(ZenCodeType.OperatorType.ADD)
     public MCBlockPos add(MCBlockPos pos) {
-        return add(pos);
+        return new MCBlockPos(internal.add(pos.internal));
     }
 
     /**
@@ -105,8 +105,8 @@ public class MCBlockPos {
      * @return a new BlockPos that is one block higher than this BlockPos
      */
     @ZenCodeType.Method
-    public BlockPos up() {
-        return internal.up();
+    public MCBlockPos up() {
+        return new MCBlockPos(internal.up());
     }
 
     /**
@@ -117,8 +117,8 @@ public class MCBlockPos {
      * @docParam n 45
      */
     @ZenCodeType.Method
-    public BlockPos up(int n) {
-        return internal.up(n);
+    public MCBlockPos up(int n) {
+        return new MCBlockPos(internal.up(n));
     }
 
     /**
@@ -127,8 +127,8 @@ public class MCBlockPos {
      * @return a new BlockPos that is one block lower than this BlockPos
      */
     @ZenCodeType.Method
-    public BlockPos down() {
-        return internal.down();
+    public MCBlockPos down() {
+        return new MCBlockPos(internal.down());
     }
 
     /**
@@ -136,8 +136,9 @@ public class MCBlockPos {
      *
      * @return a new BlockPos that is n block(s) lower than this BlockPos
      */
-    public BlockPos down(int n) {
-        return internal.down(n);
+    @ZenCodeType.Method
+    public MCBlockPos down(int n) {
+        return new MCBlockPos(internal.down(n));
     }
 
     /**
@@ -146,8 +147,8 @@ public class MCBlockPos {
      * @return a new BlockPos that is one block north of this BlockPos
      */
     @ZenCodeType.Method
-    public BlockPos north() {
-        return internal.north();
+    public MCBlockPos north() {
+        return new MCBlockPos(internal.north());
     }
 
     /**
@@ -158,8 +159,8 @@ public class MCBlockPos {
      * @docParam n 10
      */
     @ZenCodeType.Method
-    public BlockPos north(int n) {
-        return internal.north(n);
+    public MCBlockPos north(int n) {
+        return new MCBlockPos(internal.north(n));
     }
 
     /**
@@ -168,8 +169,8 @@ public class MCBlockPos {
      * @return a new BlockPos that is one block south of this BlockPos
      */
     @ZenCodeType.Method
-    public BlockPos south() {
-        return internal.south();
+    public MCBlockPos south() {
+        return new MCBlockPos(internal.south());
     }
 
     /**
@@ -180,8 +181,8 @@ public class MCBlockPos {
      * @docParam n 12
      */
     @ZenCodeType.Method
-    public BlockPos south(int n) {
-        return internal.south(n);
+    public MCBlockPos south(int n) {
+        return new MCBlockPos(internal.south(n));
     }
 
     /**
@@ -190,8 +191,8 @@ public class MCBlockPos {
      * @return a new BlockPos that is one block west of this BlockPos
      */
     @ZenCodeType.Method
-    public BlockPos west() {
-        return internal.west();
+    public MCBlockPos west() {
+        return new MCBlockPos(internal.west());
     }
 
     /**
@@ -202,8 +203,8 @@ public class MCBlockPos {
      * @docParam n 120
      */
     @ZenCodeType.Method
-    public BlockPos west(int n) {
-        return internal.west(n);
+    public MCBlockPos west(int n) {
+        return new MCBlockPos(internal.west(n));
     }
 
     /**
@@ -212,8 +213,8 @@ public class MCBlockPos {
      * @return a new BlockPos that is one block east of this BlockPos
      */
     @ZenCodeType.Method
-    public BlockPos east() {
-        return internal.east();
+    public MCBlockPos east() {
+        return new MCBlockPos(internal.east());
     }
 
     /**
@@ -224,8 +225,8 @@ public class MCBlockPos {
      * @docParam n 2
      */
     @ZenCodeType.Method
-    public BlockPos east(int n) {
-        return internal.east(n);
+    public MCBlockPos east(int n) {
+        return new MCBlockPos(internal.east(n));
     }
 
     /**

--- a/src/main/java/com/blamejared/crafttweaker/impl/util/text/MCTextFormatting.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/util/text/MCTextFormatting.java
@@ -2,10 +2,12 @@ package com.blamejared.crafttweaker.impl.util.text;
 
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker.api.brackets.CommandStringDisplayable;
+import com.blamejared.crafttweaker_annotations.annotations.*;
 import net.minecraft.util.text.TextFormatting;
 import org.openzen.zencode.java.ZenCodeType;
 
 @ZenRegister
+@Document("vanilla/api/util/text/TextFormatting")
 @ZenCodeType.Name("crafttweaker.api.text.TextFormatting")
 public class MCTextFormatting implements CommandStringDisplayable {
     


### PR DESCRIPTION
This change only reflects on types that are somehow referenced in the doc export process.
This means that if Class A references Class B and B only has `@Name` an error will be thrown.

If there however exists a Class C that only has `@Name`, no `@Document` and is not referenced by other classes, then no error is thrown for that type.
To create this, we needed a distinction between References as Using, and as Comment.
A comment would be allowed to reference a Vanilla class (especially in generated code) that therefore is not annotated by `@Document` and Method signatures may not. 
These are the `forComment` booleans that are added to some calls.

This PR also fixes the places that appeared as invalid after the change ^^