### PR TITLE
Add a way to get the internal ingredients of an MCIngredientList

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/impl/item/MCIngredientList.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/item/MCIngredientList.java
@@ -49,4 +49,8 @@ public class MCIngredientList implements IIngredient {
         Arrays.stream(ingredients).map(ing -> Arrays.asList(ing.getItems())).forEach(stacks::addAll);
         return stacks.toArray(new IItemStack[0]);
     }
+
+    public IIngredient[] getIngredients() {
+        return ingredients;
+    }
 }


### PR DESCRIPTION
I believe this is fine, unless it would be preferred to return a copy of the array so that people cannot accidentally modify it.