### PR TITLE
Fix changelog generation throwing an exception in some environments.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,10 @@ task genGitChangelog() {
         standardOutput = stdout
     }
     File file = new File("changelog.md")
-    file.write("### Current version: " + project.version)
-    file.append("\n" + stdout.toString())
-    System.out.println("Changelog generated!")
+    
+    if (file.canWrite()) {
+        file.write("### Current version: " + project.version)
+        file.append("\n" + stdout.toString())
+        System.out.println("Changelog generated!")
+    }
 }


### PR DESCRIPTION
This PR adds a "has write permission" check to the changelog generation task before attempting to generate the changelog. This avoids a permissions related crash in some environments such as the Eclipse project import preview which generates a model of the project using reduced permissions. 