### PR TITLE
Fixed scripts bigger than 64k not working on servers

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/impl/script/SerializerScript.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/script/SerializerScript.java
@@ -7,7 +7,8 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 public class SerializerScript extends ForgeRegistryEntry<IRecipeSerializer<?>> implements IRecipeSerializer<ScriptRecipe> {
-    
+    static int MAX_SERIALIZED_SCRIPT_SIZE = Short.MAX_VALUE * Short.MAX_VALUE;
+
     public ScriptRecipe read(ResourceLocation recipeId, JsonObject json) {
         // Please don't make scripts inside a datapack json 👀
         return new ScriptRecipe(recipeId, json.get("fileName").getAsString(), json.get("content").getAsString());
@@ -15,16 +16,26 @@ public class SerializerScript extends ForgeRegistryEntry<IRecipeSerializer<?>> i
     
     public ScriptRecipe read(ResourceLocation recipeId, PacketBuffer buffer) {
         String fileName = buffer.readString();
-        String firstHalf = buffer.readString();
-        String secondHalf = buffer.readString();
-        return new ScriptRecipe(recipeId, fileName, firstHalf + secondHalf);
+        int parts = buffer.readShort();
+        StringBuilder script = new StringBuilder();
+        while(parts-- > 0) {
+            script.append(buffer.readString());
+        }
+        return new ScriptRecipe(recipeId, fileName, script.toString());
     }
     
     public void write(PacketBuffer buffer, ScriptRecipe recipe) {
+        String contents = recipe.getContent();
+        if(contents.length() > MAX_SERIALIZED_SCRIPT_SIZE) {
+            throw new IllegalArgumentException("Can't serialize scripts larger than " + MAX_SERIALIZED_SCRIPT_SIZE + " bytes. please split your script in smaller parts");
+        }
+
         buffer.writeString(recipe.getFileName());
-        final int middle = recipe.getContent().length() / 2;
-        String[] halves = {recipe.getContent().substring(0, middle), recipe.getContent().substring(middle)};
-        buffer.writeString(halves[0]);
-        buffer.writeString(halves[1]);
+
+        int parts = (int) Math.ceil((double) contents.length() / (double) Short.MAX_VALUE);
+        buffer.writeShort(parts);
+        for(int i = 0; i < parts; i++) {
+            buffer.writeString(contents.substring(i * Short.MAX_VALUE, Math.min((i + 1) * Short.MAX_VALUE, contents.length())));
+        }
     }
 }


### PR DESCRIPTION
Currently scripts larger than 64k will cause a `io.netty.handler.codec.EncoderException: String too big` error, since the 2 halves will be bigger than 32k.

this PR will split the script in parts, send how many parts there are of the script and then send those parts.

the client will read how many parts to expect and then read _n_ times and compile the full script.

this moves the limit from 64K to 1G (I have tested 1G scripts, and uh, CraftTweaker runs out of memory before I could even connect to the server, so I think that's good enough)


This all motivated by trying to add a script by @ashhaxie ( https://gist.github.com/ashhaxie/fe02bf297160d39fcd8fd15af4256fdc ) which is about 129K.