### PR TITLE
Relax restriction on Recipe Serializer ID matching with Recipe Type ID

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/api/managers/IRecipeManager.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/managers/IRecipeManager.java
@@ -25,7 +25,9 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.item.crafting.RecipeManager;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.ResourceLocationException;
 import net.minecraft.util.registry.Registry;
+import net.minecraftforge.registries.ForgeRegistries;
 import org.openzen.zencode.java.ZenCodeType;
 
 import java.util.HashMap;
@@ -62,12 +64,33 @@ public interface IRecipeManager extends CommandStringDisplayable {
         }
         MapData mapData = (MapData) data;
         JsonObject recipeObject = JSON_RECIPE_GSON.fromJson(mapData.toJsonString(), JsonObject.class);
-        String recipeTypeKey = getBracketResourceLocation().toString();
+        ResourceLocation recipeTypeKey = getBracketResourceLocation();
         
-        if(!recipeObject.has("type")) {
-            recipeObject.addProperty("type", recipeTypeKey);
+        if(recipeObject.has("type")) {
+            ResourceLocation recipeSerializerKey;
+            try {
+                recipeSerializerKey = new ResourceLocation(recipeObject.get("type").getAsString());
+            } catch(ClassCastException | IllegalStateException | ResourceLocationException ex) {
+                throw new IllegalArgumentException("Expected \"type\" field to be a valid resource location.", ex);
+            }
+            if(!ForgeRegistries.RECIPE_SERIALIZERS.containsKey(recipeSerializerKey)) {
+                throw new IllegalArgumentException("Recipe Serializer \"" + recipeSerializerKey + "\" does not exist.");
+            }
+        } else {
+            if(ForgeRegistries.RECIPE_SERIALIZERS.containsKey(recipeTypeKey)) {
+                recipeObject.addProperty("type", recipeTypeKey.toString());
+            } else {
+                throw new IllegalArgumentException("Recipe Type \"" + recipeTypeKey + "\" does not have a Recipe Serializer of the same ID."
+                        + " Please specify a serializer manually using the \"type\" field in the JSON object.");
+            }
         }
         IRecipe<?> iRecipe = RecipeManager.deserializeRecipe(new ResourceLocation(CraftTweaker.MODID, name), recipeObject);
+        IRecipeType<?> recipeType = iRecipe.getType();
+        if(recipeType != getRecipeType()) {
+            throw new IllegalArgumentException("Recipe Serializer \"" + iRecipe.getSerializer().getRegistryName()
+                    + "\" resulted in Recipe Type \"" + Registry.RECIPE_TYPE.getKey(recipeType)
+                    + "\" but expected Recipe Type \"" + recipeTypeKey + "\".");
+        }
         CraftTweakerAPI.apply(new ActionAddRecipe(this, iRecipe, ""));
     }
     

--- a/src/main/java/com/blamejared/crafttweaker/api/managers/IRecipeManager.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/managers/IRecipeManager.java
@@ -64,10 +64,7 @@ public interface IRecipeManager extends CommandStringDisplayable {
         JsonObject recipeObject = JSON_RECIPE_GSON.fromJson(mapData.toJsonString(), JsonObject.class);
         String recipeTypeKey = getBracketResourceLocation().toString();
         
-        if(recipeObject.has("type")) {
-            if(!recipeObject.get("type").getAsString().equals(recipeTypeKey))
-                throw new IllegalArgumentException("Cannot override recipe type! Given: \"" + recipeObject.get("type").getAsString() + "\", Expected: \"" + recipeTypeKey + "\"");
-        } else {
+        if(!recipeObject.has("type")) {
             recipeObject.addProperty("type", recipeTypeKey);
         }
         IRecipe<?> iRecipe = RecipeManager.deserializeRecipe(new ResourceLocation(CraftTweaker.MODID, name), recipeObject);


### PR DESCRIPTION
This PR relaxes the restriction for the Recipe Type and Recipe Serializer IDs having to match and instead checks that the recipe serializer produces the expected recipe type instead. It also adds a bunch of error checking and messages.
```
Cannot override recipe type! Given: "minecraft:crafting_shapeless", Expected: "minecraft:crafting"
```
```zs
<recipetype:minecraft:crafting>.addJSONRecipe("apple_from_stone", {
    "type": "minecraft:crafting_shapeless",
    "ingredients": [
        {
            "tag": "minecraft:stone_tool_materials"
        }
    ],
    "result": {
        "item": "minecraft:apple",
        "count": 1
    }
});
```