### PR TITLE
Remove unneeded isSimple override

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/api/item/IngredientList.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/item/IngredientList.java
@@ -41,12 +41,6 @@ public class IngredientList extends CompoundIngredient {
         return Serializer.INSTANCE;
     }
     
-    @Override
-    public boolean isSimple() {
-        
-        return false;
-    }
-    
     public static class Serializer implements IIngredientSerializer<IngredientList> {
         
         public static final Serializer INSTANCE = new Serializer();


### PR DESCRIPTION
Removes one of the overrides introduced in https://github.com/CraftTweaker/CraftTweaker/commit/03f921f5d6f13c74fe3208a1cd2d42b9a058b5c7 as it isn't needed in this case as CompoundIngredient which IngredientList extends already properly calculates isSimple.