### PR TITLE
Add ToolType support.

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/api/item/IItemStack.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/item/IItemStack.java
@@ -5,13 +5,10 @@ import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker.api.data.IData;
 import com.blamejared.crafttweaker.api.data.NBTConverter;
-import com.blamejared.crafttweaker.api.item.tooltip.ITooltipFunction;
 import com.blamejared.crafttweaker.impl.actions.items.ActionSetBurnTime;
-import com.blamejared.crafttweaker.impl.actions.items.tooltips.*;
 import com.blamejared.crafttweaker.impl.data.MapData;
 import com.blamejared.crafttweaker.impl.food.MCFood;
 import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
-import com.blamejared.crafttweaker.impl.util.text.MCTextComponent;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
 import com.blamejared.crafttweaker_annotations.annotations.ZenWrapper;
 import net.minecraft.item.Item;
@@ -19,9 +16,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.ForgeHooks;
+import net.minecraftforge.common.ToolType;
 import org.openzen.zencode.java.ZenCodeType;
-
-import java.util.regex.Pattern;
 
 /**
  * This represents an item.
@@ -411,6 +407,11 @@ public interface IItemStack extends IIngredient, IIngredientWithAmount {
     
     @ZenCodeType.Getter("damage")
     int getDamage();
+
+    @ZenCodeType.Getter("toolTypes")
+    default ToolType[] getToolTypes() {
+        return getInternal().getToolTypes().toArray(new ToolType[0]);
+    }
     
     /**
      * Gets the internal {@link ItemStack} for this IItemStack.

--- a/src/main/java/com/blamejared/crafttweaker/impl/brackets/BracketDumpers.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/brackets/BracketDumpers.java
@@ -8,6 +8,7 @@ import com.blamejared.crafttweaker.impl.tag.registry.CrTTagRegistry;
 import com.blamejared.crafttweaker.impl_native.blocks.ExpandBlock;
 import com.blamejared.crafttweaker.impl_native.potion.ExpandEffect;
 import com.blamejared.crafttweaker.impl_native.potion.ExpandPotion;
+import com.blamejared.crafttweaker.impl_native.tool.ExpandToolType;
 import com.blamejared.crafttweaker.impl_native.util.ExpandDamageSource;
 import com.blamejared.crafttweaker.impl_native.util.ExpandEquipmentSlotType;
 import com.blamejared.crafttweaker.impl_native.world.ExpandBiome;
@@ -18,14 +19,18 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.common.ToolType;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.openzen.zencode.java.ZenCodeType;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @ZenRegister
@@ -160,5 +165,31 @@ public class BracketDumpers {
                 .map(ExpandBiome::getCommandString)
                 .collect(Collectors.toList());
     }
-    
+
+    @BracketDumper("tooltype")
+    public static Collection<String> getToolTypeDump() {
+        return getToolTypeValues()
+                .values()
+                .stream()
+                .map(ExpandToolType::getCommandString)
+                .collect(Collectors.toList());
+    }
+
+    private static Map<String, ToolType> toolTypeValues = null;
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, ToolType> getToolTypeValues() {
+        if (toolTypeValues == null) {
+            try {
+                Field field = ToolType.class.getDeclaredField("VALUES");
+                field.setAccessible(true);
+                toolTypeValues = (Map<String, ToolType>) field.get(null);
+            } catch(IllegalAccessException | NoSuchFieldException e) {
+                e.printStackTrace();
+                toolTypeValues = Collections.emptyMap();
+            }
+        }
+        return toolTypeValues;
+    }
+
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/brackets/BracketHandlers.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/brackets/BracketHandlers.java
@@ -32,6 +32,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.common.ToolType;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -484,5 +485,21 @@ public class BracketHandlers {
     @BracketResolver("damagesource")
     public static DamageSource getDamageSource(String tokens) {
         return ExpandDamageSource.PRE_REGISTERED_DAMAGE_SOURCES.getOrDefault(tokens, new DamageSource(tokens));
+    }
+    
+    /**
+     * Gets a tool type by name.
+     * If the tool type doesn't exist yet, this will create a new one with the given name
+     *
+     * @param tokens the tool type's name
+     *
+     * @return The found tool type or a new one
+     *
+     * @docParam tokens "shovel"
+     */
+    @ZenCodeType.Method
+    @BracketResolver("tooltype")
+    public static ToolType getToolType(String tokens) {
+        return ToolType.get(tokens);
     }
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/brackets/BracketValidators.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/brackets/BracketValidators.java
@@ -12,6 +12,7 @@ import org.openzen.zencode.java.ZenCodeType;
 
 import java.util.Locale;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 @ZenRegister
 @ZenCodeType.Name("crafttweaker.api.BracketValidators")
@@ -169,6 +170,12 @@ public class BracketValidators {
     @BracketValidator("resource")
     public static boolean validateResourceBracket(String tokens) {
         return ResourceLocation.tryCreate(tokens) != null;
+    }
+    
+    @ZenCodeType.Method
+    @BracketValidator("tooltype")
+    public static boolean validateToolTypeBracket(String tokens) {
+        return tokens.chars().allMatch(c -> ('a' <= c && c <= 'z') || c == '_');
     }
 
     public static boolean validateBracket(String bracketName, String tokens, Function<String, ?> bracketMethod, boolean logError) {

--- a/src/main/java/com/blamejared/crafttweaker/impl_native/blocks/ExpandBlockState.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl_native/blocks/ExpandBlockState.java
@@ -9,6 +9,7 @@ import com.google.common.collect.ImmutableMap;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.state.Property;
+import net.minecraftforge.common.ToolType;
 import org.openzen.zencode.java.ZenCodeType;
 
 import java.util.*;
@@ -117,6 +118,16 @@ public class ExpandBlockState {
     public static boolean hasProperty(BlockState internal, String name) {
         Property<?> prop = internal.getBlock().getStateContainer().getProperty(name);
         return prop != null;
+    }
+    
+    @ZenCodeType.Getter("harvestTool")
+    public static ToolType getHarvestTool(BlockState internal) {
+        return internal.getHarvestTool();
+    }
+
+    @ZenCodeType.Getter("harvestLevel")
+    public static int getHarvestLevel(BlockState internal) {
+        return internal.getHarvestLevel();
     }
     
     

--- a/src/main/java/com/blamejared/crafttweaker/impl_native/event/block/ExpandBlockToolInteractEvent.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl_native/event/block/ExpandBlockToolInteractEvent.java
@@ -7,6 +7,7 @@ import com.blamejared.crafttweaker_annotations.annotations.Document;
 import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraftforge.common.ToolType;
 import net.minecraftforge.event.world.BlockEvent;
 import org.openzen.zencode.java.ZenCodeType;
 
@@ -37,9 +38,9 @@ public class ExpandBlockToolInteractEvent {
     
     @ZenCodeType.Getter("toolType")
     @ZenCodeType.Method
-    public static String getToolType(BlockEvent.BlockToolInteractEvent internal) {
+    public static ToolType getToolType(BlockEvent.BlockToolInteractEvent internal) {
         
-        return internal.getToolType().getName();
+        return internal.getToolType();
     }
     
     /**

--- a/src/main/java/com/blamejared/crafttweaker/impl_native/tool/ExpandToolType.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl_native/tool/ExpandToolType.java
@@ -1,0 +1,34 @@
+package com.blamejared.crafttweaker.impl_native.tool;
+
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
+import net.minecraftforge.common.ToolType;
+import org.openzen.zencode.java.ZenCodeType;
+
+/**
+ * This is the vanilla ToolType.
+ */
+@ZenRegister
+@Document("vanilla/api/tool/ToolType")
+@NativeTypeRegistration(value = ToolType.class, zenCodeName = "crafttweaker.api.tool.ToolType")
+public class ExpandToolType {
+    /**
+     * Gets the name of this ToolType.
+     */
+    @ZenCodeType.Method
+    @ZenCodeType.Getter("name")
+    public static String getName(ToolType _this) {
+        return _this.getName();
+    }
+
+    @ZenCodeType.Caster
+    public static String asString(ToolType _this) {
+        return _this.toString();
+    }
+    
+    @ZenCodeType.Getter("commandString")
+    public static String getCommandString(ToolType _this) {
+        return "<tooltype:" + _this.getName() + ">";
+    }
+}


### PR DESCRIPTION
This PR adds:

- `ExpandToolType` - The `ToolType` native class, with support for getting the name of the tool type.
- The `<tooltype:{name}>` Bracket Handler.
  - A validator for it.
  - A bracket dumper for it.
    - This reflects a private field, which may need to be reconsidered.
- A `toolTypes` getter for `IItemStack`.
- `harvestTool` and `harvestLevel` for `BlockState`s.

And changes:

- The `toolType` getter for `BlockToolInteractEvent` to return the `ToolType` itself rather than its name.

How this affects [ContentTweaker](https://github.com/CraftTweaker/ContentTweaker/blob/develop/1.16/src/main/java/com/blamejared/contenttweaker/wrappers/MCToolType.java) needs to be considered. The Bracket Handler conflicts, and ContentTweaker could use the native `ToolType`s itself.
