### PR TITLE
Fix JEI describe action

### DIFF
--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEI.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEI.java
@@ -1,18 +1,20 @@
 package crafttweaker.mods.jei;
 
-import crafttweaker.*;
-import crafttweaker.annotations.*;
-import crafttweaker.api.item.*;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.oredict.IOreDictEntry;
-import crafttweaker.mc1120.liquid.MCLiquidStack;
-import crafttweaker.mc1120.oredict.MCOreDictEntry;
 import crafttweaker.mc1120.recipes.MCRecipeManager;
 import crafttweaker.mods.jei.actions.*;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.*;
+import net.minecraftforge.fluids.FluidStack;
 import stanhebben.zenscript.annotations.Optional;
-import stanhebben.zenscript.annotations.*;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEI.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/JEI.java
@@ -5,6 +5,8 @@ import crafttweaker.annotations.*;
 import crafttweaker.api.item.*;
 import crafttweaker.api.liquid.ILiquidStack;
 import crafttweaker.api.oredict.IOreDictEntry;
+import crafttweaker.mc1120.liquid.MCLiquidStack;
+import crafttweaker.mc1120.oredict.MCOreDictEntry;
 import crafttweaker.mc1120.recipes.MCRecipeManager;
 import crafttweaker.mods.jei.actions.*;
 import net.minecraft.item.ItemStack;
@@ -13,6 +15,7 @@ import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * MineTweaker JEI support.
@@ -81,27 +84,37 @@ public class JEI {
         
     }
     
-    @ZenMethod
+    @Deprecated
     public static void addDescription(IItemStack stack, String... description) {
-        DESCRIPTIONS.add(new DescribeAction(Collections.singletonList(stack), description, stack.toString()));
+        addDescription(((IIngredient) stack), description);
     }
     
     
-    @ZenMethod
+    @Deprecated
     public static void addDescription(IItemStack[] stack, String... description) {
-        DESCRIPTIONS.add(new DescribeAction(Arrays.asList(stack), description, "IItemStack[]"));
+        addDescription(((IIngredient[]) stack), description);
     }
     
     
-    @ZenMethod
+    @Deprecated
     public static void addDescription(IOreDictEntry dict, String... description) {
-        DESCRIPTIONS.add(new DescribeAction(dict.getItems(), description, dict.toString()));
+        addDescription(((IIngredient) dict), description);
     }
     
     
-    @ZenMethod
+    @Deprecated
     public static void addDescription(ILiquidStack stack, String... description) {
-        DESCRIPTIONS.add(new DescribeAction(Collections.singletonList(stack.withAmount(Fluid.BUCKET_VOLUME)), description, stack.toString()));
+        addDescription(((IIngredient) stack), description);
+    }
+
+    @ZenMethod
+    public static void addDescription(IIngredient ingredient, String... description) {
+        DESCRIPTIONS.add(new DescribeAction(Collections.singletonList(ingredient), description, ingredient.toCommandString()));
+    }
+
+    @ZenMethod
+    public static void addDescription(IIngredient[] ingredients, String... description) {
+        DESCRIPTIONS.add(new DescribeAction(Arrays.asList(ingredients), description, Arrays.stream(ingredients).map(IIngredient::toCommandString).collect(Collectors.joining(", ", "[", "]"))));
     }
     
     

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/actions/DescribeAction.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/actions/DescribeAction.java
@@ -14,47 +14,47 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class DescribeAction implements IAction {
-	private final List<IItemStack> itemStacks = new ArrayList<>();
-	private final List<ILiquidStack> fluidStacks = new ArrayList<>();
-	private final String[] description;
-	private final String name;
-	
-	@Deprecated
-	public DescribeAction(IItemStack stack, String[] description) {
-		this(Collections.singletonList(stack), description, stack.toString());
-	}
-	/**
-	 * Used to add a JEI Description page to the given ingredients
-	 * @param ingredients The ingredients to be given descriptions
-	 * @param description The Description: one or more lines per item, auto wrap if lines are too long
-	 * @param name Solely for the User output, should be a representation of stack 
-	 */
-	public DescribeAction(List<? extends IIngredient> ingredients, String[] description, String name) {
-		ingredients.forEach(it -> {
-			List<ILiquidStack> liquids = it.getLiquids();
-			if (liquids.isEmpty()) {
-				itemStacks.addAll(it.getItems());
-			} else {
-				fluidStacks.addAll(liquids);
-			}
-		});
-		this.description = description;
-		this.name = name;
-	}
+    private final List<IItemStack> itemStacks = new ArrayList<>();
+    private final List<ILiquidStack> fluidStacks = new ArrayList<>();
+    private final String[] description;
+    private final String name;
 
-	@Override
-	public void apply() {
-		if (!itemStacks.isEmpty()) {
-			JEIAddonPlugin.modRegistry.addIngredientInfo(itemStacks.stream().map(CraftTweakerMC::getItemStack).collect(Collectors.toList()), VanillaTypes.ITEM, description);
-		}
+    @Deprecated
+    public DescribeAction(IItemStack stack, String[] description) {
+        this(Collections.singletonList(stack), description, stack.toString());
+    }
+    /**
+     * Used to add a JEI Description page to the given ingredients
+     * @param ingredients The ingredients to be given descriptions
+     * @param description The Description: one or more lines per item, auto wrap if lines are too long
+     * @param name Solely for the User output, should be a representation of stack
+     */
+    public DescribeAction(List<? extends IIngredient> ingredients, String[] description, String name) {
+        ingredients.forEach(it -> {
+            List<ILiquidStack> liquids = it.getLiquids();
+            if (liquids.isEmpty()) {
+                itemStacks.addAll(it.getItems());
+            } else {
+                fluidStacks.addAll(liquids);
+            }
+        });
+        this.description = description;
+        this.name = name;
+    }
 
-		if (!fluidStacks.isEmpty()) {
-			JEIAddonPlugin.modRegistry.addIngredientInfo(fluidStacks.stream().map(CraftTweakerMC::getLiquidStack).collect(Collectors.toList()), VanillaTypes.FLUID, description);
-		}
-	}
+    @Override
+    public void apply() {
+        if (!itemStacks.isEmpty()) {
+            JEIAddonPlugin.modRegistry.addIngredientInfo(itemStacks.stream().map(CraftTweakerMC::getItemStack).collect(Collectors.toList()), VanillaTypes.ITEM, description);
+        }
 
-	@Override
-	public String describe() {
-		return "Adding description in JEI for: " + name;
-	}
+        if (!fluidStacks.isEmpty()) {
+            JEIAddonPlugin.modRegistry.addIngredientInfo(fluidStacks.stream().map(CraftTweakerMC::getLiquidStack).collect(Collectors.toList()), VanillaTypes.FLUID, description);
+        }
+    }
+
+    @Override
+    public String describe() {
+        return "Adding description in JEI for: " + name;
+    }
 }

--- a/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/actions/DescribeAction.java
+++ b/CraftTweaker2-MC1120-Mod-JEI/src/main/java/crafttweaker/mods/jei/actions/DescribeAction.java
@@ -1,17 +1,21 @@
 package crafttweaker.mods.jei.actions;
 
+import crafttweaker.IAction;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.liquid.ILiquidStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import crafttweaker.mods.jei.JEIAddonPlugin;
+import mezz.jei.api.ingredients.VanillaTypes;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import crafttweaker.CraftTweakerAPI;
-import crafttweaker.IAction;
-import crafttweaker.api.item.IIngredient;
-import crafttweaker.api.item.IItemStack;
-import crafttweaker.mods.jei.JEIAddonPlugin;
-
 public class DescribeAction implements IAction {
-	private final List<?> stack;
+	private final List<IItemStack> itemStacks = new ArrayList<>();
+	private final List<ILiquidStack> fluidStacks = new ArrayList<>();
 	private final String[] description;
 	private final String name;
 	
@@ -20,42 +24,37 @@ public class DescribeAction implements IAction {
 		this(Collections.singletonList(stack), description, stack.toString());
 	}
 	/**
-	 * Used to add a JEI Description page to the given items/fluids/...
-	 * Objects need to implement {@code getInternal()} and the result of this method needs to be
-	 * <ol type = "A">
-	 * <li> of a Minecraft ingredient type (e.g. ItemStack, FluidStack,...)</li>
-	 * <li> all items in the list need to be of the same class</li>
-	 * </ol>
-	 * @param stack The objects to be given descriptions
+	 * Used to add a JEI Description page to the given ingredients
+	 * @param ingredients The ingredients to be given descriptions
 	 * @param description The Description: one or more lines per item, auto wrap if lines are too long
 	 * @param name Solely for the User output, should be a representation of stack 
 	 */
-	public DescribeAction(List<? extends IIngredient> stack, String[] description, String name) {
-		this.stack = stack.stream().map(IIngredient::getInternal).collect(Collectors.toList());
+	public DescribeAction(List<? extends IIngredient> ingredients, String[] description, String name) {
+		ingredients.forEach(it -> {
+			List<ILiquidStack> liquids = it.getLiquids();
+			if (liquids.isEmpty()) {
+				itemStacks.addAll(it.getItems());
+			} else {
+				fluidStacks.addAll(liquids);
+			}
+		});
 		this.description = description;
 		this.name = name;
 	}
 
 	@Override
 	public void apply() {
-		if(stack.isEmpty()) {
-			CraftTweakerAPI.logError(name + " is empty!");
-			return;
-		} else if (!checkClasses()) {
-			CraftTweakerAPI.logError(name + " needs to consist only of items of the same type!");
-			return;
+		if (!itemStacks.isEmpty()) {
+			JEIAddonPlugin.modRegistry.addIngredientInfo(itemStacks.stream().map(CraftTweakerMC::getItemStack).collect(Collectors.toList()), VanillaTypes.ITEM, description);
 		}
-			
-        JEIAddonPlugin.modRegistry.addIngredientInfo(stack, JEIAddonPlugin.itemRegistry.getIngredientType(stack.get(0).getClass()), description);
+
+		if (!fluidStacks.isEmpty()) {
+			JEIAddonPlugin.modRegistry.addIngredientInfo(fluidStacks.stream().map(CraftTweakerMC::getLiquidStack).collect(Collectors.toList()), VanillaTypes.FLUID, description);
+		}
 	}
 
 	@Override
 	public String describe() {
 		return "Adding description in JEI for: " + name;
-	}
-	
-	public boolean checkClasses() {
-		Class<?> clazz = stack.get(0).getClass();
-		return stack.stream().map(Object::getClass).allMatch(i -> i == clazz);
 	}
 }


### PR DESCRIPTION
The previous describe action implementation is pretty weird. The return type of `IIngredient#getInternal` is various. `MCItemStack` returns `ItemStack`, `MCOreDictEntry` returns `String`, `IngredientOr` returns `IIngredient[]`. But JEI `IIngredientRegistry#getIngredientType` could not accept all of them. Moreover, currently, `IModRegistry#addIngredientInfo` matches wrong overload, which the first parameter is `T`, rather than `List<T>`. 
It produces `[22:23:33] [Client thread/INFO] [STDERR]: [crafttweaker.mods.jei.JEIMod:onRegistered:89]: java.lang.IllegalArgumentException: Unknown ingredient class: class java.util.ArrayList` Error.

This PR refactors descibe action, makes the action only accept IItemStack and ILiquidStack, and use `IIngredient#getItems/getLiquids`, rather than `getInternal`