### PR TITLE
fix(MCItemBlock): fix return null when item is not isEmpty()

### DIFF
--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCItemBlock.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/block/MCItemBlock.java
@@ -35,12 +35,10 @@ public class MCItemBlock implements IBlock {
 
     @Override
     public IData getTileData() {
-        if(!item.isEmpty()) {
+        if(item.isEmpty() || item.getTagCompound() == null) {
             return null;
         }
-        if(item.getTagCompound() == null)
-            return null;
-        
+
         return CraftTweakerMC.getIData(item.getTagCompound());
     }
     


### PR DESCRIPTION
fix return null when item is not isEmpty()