### PR TITLE
Reimplement /ct conflicts feature

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/api/recipes/IRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/recipes/IRecipeHandler.java
@@ -274,7 +274,7 @@ public interface IRecipeHandler<T extends IRecipe<?>> {
      *
      * @implNote By default, this method returns {@code false}.
      */
-    default <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final T firstRecipe, final U secondRecipe) {
+    default <U extends IRecipe<?>> boolean doesConflict(final IRecipeManager manager, final T firstRecipe, final U secondRecipe) {
         
         return false;
     }

--- a/src/main/java/com/blamejared/crafttweaker/api/recipes/IRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/recipes/IRecipeHandler.java
@@ -262,6 +262,7 @@ public interface IRecipeHandler<T extends IRecipe<?>> {
      * @param firstRecipe The recipe which should be checked for conflict.
      * @param secondRecipe The other recipe which {@code firstRecipe} should be checked against. The recipe may or may
      *                     not be of the same type of {@code firstRecipe}. See the API note section for more details.
+     * @param <U> The type of {@code secondRecipe}.
      * @return Whether the {@code firstRecipe} conflicts with {@code secondRecipe} or not.
      *
      * @apiNote The reason for which {@code secondRecipe} is specified as simply {@link IRecipe} instead of as the
@@ -273,7 +274,7 @@ public interface IRecipeHandler<T extends IRecipe<?>> {
      *
      * @implNote By default, this method returns {@code false}.
      */
-    default boolean conflictsWith(final IRecipeManager manager, final T firstRecipe, final IRecipe<?> secondRecipe) {
+    default <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final T firstRecipe, final U secondRecipe) {
         
         return false;
     }

--- a/src/main/java/com/blamejared/crafttweaker/api/recipes/IRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/recipes/IRecipeHandler.java
@@ -249,4 +249,33 @@ public interface IRecipeHandler<T extends IRecipe<?>> {
                 .getName() + "' with manager " + manager.getCommandString());
     }
     
+    /**
+     * Checks if the two recipes conflict with each other.
+     *
+     * <p>In this case, a conflict is defined as the two recipes being made in the exact same way (e.g. with the same
+     * shape and the same ingredients if the two recipes are shaped crafting table ones).</p>
+     *
+     * <p>Conflicts are also considered symmetrical in this implementation, which means that if {@code firstRecipe}
+     * conflicts with {@code secondRecipe}, the opposite is also true.</p>
+     *
+     * @param manager The recipe manager responsible for this kind of recipes.
+     * @param firstRecipe The recipe which should be checked for conflict.
+     * @param secondRecipe The other recipe which {@code firstRecipe} should be checked against. The recipe may or may
+     *                     not be of the same type of {@code firstRecipe}. See the API note section for more details.
+     * @return Whether the {@code firstRecipe} conflicts with {@code secondRecipe} or not.
+     *
+     * @apiNote The reason for which {@code secondRecipe} is specified as simply {@link IRecipe} instead of as the
+     * generic parameter {@code T} is to allow more flexibility in the conflict checking. In fact, this choice allows
+     * for checking to also occur between different types of recipes (e.g. shaped vs shapeless crafting table recipes),
+     * allowing for a broader range of checking. Nevertheless, the two recipes are <strong>ensured</strong> to be of the
+     * same {@link net.minecraft.item.crafting.IRecipeType recipe type} (i.e.
+     * {@code firstRecipe.getType() == secondRecipe.getType()}).
+     *
+     * @implNote By default, this method returns {@code false}.
+     */
+    default boolean conflictsWith(final IRecipeManager manager, final T firstRecipe, final IRecipe<?> secondRecipe) {
+        
+        return false;
+    }
+    
 }

--- a/src/main/java/com/blamejared/crafttweaker/api/recipes/RecipeHandlerRegistry.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/recipes/RecipeHandlerRegistry.java
@@ -4,6 +4,7 @@ import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.api.util.InstantiationUtil;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
 import net.minecraft.item.crafting.IRecipe;
 import org.openzen.zenscript.codemodel.Modifiers;
@@ -28,7 +29,7 @@ public final class RecipeHandlerRegistry {
             return String.format(
                     "~~ Recipe name: %s, Outputs: %s, Inputs: [%s], Recipe Class: %s, Recipe Serializer: %s ~~",
                     recipe.getId(),
-                    new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                    ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
                     recipe.getIngredients()
                             .stream()
                             .map(IIngredient::fromIngredient)

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/CTCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/CTCommands.java
@@ -124,6 +124,8 @@ public class CTCommands {
     
     private static void registerCommandInternal(LiteralArgumentBuilder<CommandSource> root, com.blamejared.crafttweaker.impl.commands.CommandImpl command) {
         
+        if (command.getCaller() == null) return;
+        
         LiteralArgumentBuilder<CommandSource> literalCommand = Commands.literal(command.getName());
         final Map<String, com.blamejared.crafttweaker.impl.commands.CommandImpl> subCommands = command.getChildCommands();
         if(!subCommands.isEmpty()) {
@@ -142,7 +144,7 @@ public class CTCommands {
         
         registerCustomCommand(literal);
         if(name != null && description != null) {
-            COMMANDS.put(name, new CommandImpl(name, description, (context -> 0)));
+            COMMANDS.put(name, new CommandImpl(name, description, null));
         }
     }
     
@@ -238,7 +240,7 @@ public class CTCommands {
         public CommandCaller getCaller() {
             
             final com.blamejared.crafttweaker.impl.commands.CommandCaller caller = super.getCaller();
-            return caller instanceof CommandCaller ? (CommandCaller) caller : caller::executeCommand;
+            return (caller == null || caller instanceof CommandCaller)? (CommandCaller) caller : caller::executeCommand;
         }
         
         @Deprecated

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/CTCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/CTCommands.java
@@ -2,7 +2,7 @@ package com.blamejared.crafttweaker.impl.commands;
 
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.CraftTweakerRegistry;
-import com.blamejared.crafttweaker.impl.commands.crafttweaker.ConflictCommands;
+import com.blamejared.crafttweaker.impl.commands.crafttweaker.conflict.ConflictCommand;
 import com.blamejared.crafttweaker.impl.commands.crafttweaker.DumpCommands;
 import com.blamejared.crafttweaker.impl.commands.crafttweaker.HandCommands;
 import com.blamejared.crafttweaker.impl.commands.crafttweaker.HelpCommand;
@@ -43,7 +43,7 @@ public class CTCommands {
     
     public static void init(CommandDispatcher<CommandSource> dispatcher) {
         
-        ConflictCommands.registerConflictCommands(CTCommands::registerCustomCommand);
+        ConflictCommand.registerConflictCommands(CTCommands::registerCustomCommand);
         DumpCommands.registerDumpCommands(() -> COMMANDS);
         ExamplesCommand.register();
         HandCommands.registerHandCommands();

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/CTCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/CTCommands.java
@@ -2,6 +2,7 @@ package com.blamejared.crafttweaker.impl.commands;
 
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.CraftTweakerRegistry;
+import com.blamejared.crafttweaker.impl.commands.crafttweaker.ConflictCommands;
 import com.blamejared.crafttweaker.impl.commands.crafttweaker.DumpCommands;
 import com.blamejared.crafttweaker.impl.commands.crafttweaker.HandCommands;
 import com.blamejared.crafttweaker.impl.commands.crafttweaker.HelpCommand;
@@ -42,6 +43,7 @@ public class CTCommands {
     
     public static void init(CommandDispatcher<CommandSource> dispatcher) {
         
+        ConflictCommands.registerConflictCommands(CTCommands::registerCustomCommand);
         DumpCommands.registerDumpCommands(() -> COMMANDS);
         ExamplesCommand.register();
         HandCommands.registerHandCommands();

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/CTCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/CTCommands.java
@@ -37,6 +37,7 @@ public class CTCommands {
     public static void initArgumentTypes() {
         
         ArgumentTypes.register("crafttweaker:item_argument", CTItemArgument.class, new ArgumentSerializer<>(() -> CTItemArgument.INSTANCE));
+        ArgumentTypes.register("crafttweaker:recipe_type_argument", CTRecipeTypeArgument.class, new ArgumentSerializer<>(() -> CTRecipeTypeArgument.INSTANCE));
     }
     
     public static void init(CommandDispatcher<CommandSource> dispatcher) {

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/CTItemArgument.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/CTItemArgument.java
@@ -7,12 +7,18 @@ import com.google.common.collect.Lists;
 import com.mojang.brigadier.LiteralMessage;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.command.ISuggestionProvider;
+import net.minecraftforge.registries.ForgeRegistries;
 import org.openzen.zenscript.lexer.ParseException;
 
 import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -39,6 +45,12 @@ public enum CTItemArgument implements ArgumentType<IItemStack> {
             reader.setCursor(reader.getCursor() + itemLocation.length() + "<item:>.withTag(".length() + e.position.getFromLineOffset());
             throw MALFORMED_DATA.createWithContext(reader, e);
         }
+    }
+    
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(CommandContext<S> context, SuggestionsBuilder builder) {
+        
+        return ISuggestionProvider.suggest(ForgeRegistries.ITEMS.getKeys().stream().map(it -> String.format("<item:%s>", it)), builder);
     }
     
     @Override

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/CTRecipeTypeArgument.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/CTRecipeTypeArgument.java
@@ -1,0 +1,59 @@
+package com.blamejared.crafttweaker.impl.commands;
+
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.brackets.RecipeTypeBracketHandler;
+import com.google.common.collect.Lists;
+import com.mojang.brigadier.LiteralMessage;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.minecraft.command.ISuggestionProvider;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public enum CTRecipeTypeArgument implements ArgumentType<IRecipeManager> {
+    INSTANCE;
+    
+    private static final Collection<String> EXAMPLES = Lists.newArrayList("<recipetype:minecraft:crafting>", "<recipetype:minecraft:blasting>");
+    private static final SimpleCommandExceptionType INVALID_STRING = new SimpleCommandExceptionType(new LiteralMessage("Invalid String"));
+    private static final Pattern ITEM_PATTERN = Pattern.compile("<recipetype:(\\w+:\\w+)>");
+    
+    
+    @Override
+    public IRecipeManager parse(final StringReader reader) throws CommandSyntaxException {
+        
+        final Matcher matcher = ITEM_PATTERN.matcher(reader.getRemaining());
+
+        if (!matcher.find()) {
+            
+            throw INVALID_STRING.createWithContext(reader);
+        }
+        
+        final String location = matcher.group(1);
+        
+        final IRecipeManager type = RecipeTypeBracketHandler.getRecipeManager(location);
+        reader.setCursor(reader.getCursor() + matcher.group(0).length());
+        return type;
+    }
+    
+    @Override
+    public <S> CompletableFuture<Suggestions> listSuggestions(final CommandContext<S> context, final SuggestionsBuilder builder) {
+        
+        return ISuggestionProvider.suggest(RecipeTypeBracketHandler.getManagerInstances().stream().map(IRecipeManager::getCommandString), builder);
+    }
+    
+    
+    @Override
+    public Collection<String> getExamples() {
+        
+        return EXAMPLES;
+    }
+    
+}

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/CTRecipeTypeArgument.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/CTRecipeTypeArgument.java
@@ -22,7 +22,7 @@ public enum CTRecipeTypeArgument implements ArgumentType<IRecipeManager> {
     INSTANCE;
     
     private static final Collection<String> EXAMPLES = Lists.newArrayList("<recipetype:minecraft:crafting>", "<recipetype:minecraft:blasting>");
-    private static final SimpleCommandExceptionType INVALID_STRING = new SimpleCommandExceptionType(new LiteralMessage("Invalid String"));
+    private static final SimpleCommandExceptionType INVALID_STRING = new SimpleCommandExceptionType(new LiteralMessage("Unknown Recipe Type"));
     private static final Pattern ITEM_PATTERN = Pattern.compile("<recipetype:(\\w+:\\w+)>");
     
     

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/ConflictCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/ConflictCommands.java
@@ -71,7 +71,6 @@ public final class ConflictCommands {
     private static final class RecipeIterator implements PrimitiveIterator.OfLong {
         
         private final int size;
-        private final int half;
         
         private int currentLeft;
         private int currentRight;
@@ -80,9 +79,8 @@ public final class ConflictCommands {
         RecipeIterator(final int size) {
             
             this.size = size;
-            this.half = (int) Math.ceil(((double) this.size) / 2.0); // If size is odd, then we will have a duplicate rather than potentially "forgetting" a pairing.
             this.currentLeft = 0;
-            this.currentRight = this.half;
+            this.currentRight = this.currentLeft + 1;
             this.kill = false;
         }
         
@@ -93,8 +91,8 @@ public final class ConflictCommands {
             
             final long current = make(this.currentLeft, this.currentRight);
             if (++this.currentRight >= this.size) {
-                if (++this.currentLeft >= this.half) this.kill = true;
-                this.currentRight = this.half;
+                if (++this.currentLeft >= this.size - 1) this.kill = true;
+                this.currentRight = this.currentLeft + 1;
             }
             
             return current;

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/ConflictCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/ConflictCommands.java
@@ -1,0 +1,286 @@
+package com.blamejared.crafttweaker.impl.commands.crafttweaker;
+
+import com.blamejared.crafttweaker.CraftTweaker;
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.CraftTweakerRegistry;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.brackets.RecipeTypeBracketHandler;
+import com.blamejared.crafttweaker.impl.commands.CTRecipeTypeArgument;
+import com.blamejared.crafttweaker.impl.commands.CommandUtilities;
+import com.blamejared.crafttweaker.impl.item.MCItemStack;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.Commands;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.concurrent.ThreadTaskExecutor;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.LogicalSidedProvider;
+import net.minecraftforge.fml.common.thread.EffectiveSide;
+import org.apache.logging.log4j.util.TriConsumer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.PrimitiveIterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public final class ConflictCommands {
+    
+    private static final class DescriptiveFilter implements Predicate<Map.Entry<ResourceLocation, IRecipe<?>>> {
+        
+        private final Predicate<IRecipe<?>> delegate;
+        private final String description;
+        
+        DescriptiveFilter(final Predicate<IRecipe<?>> delegate, final String description) {
+            
+            this.delegate = delegate;
+            this.description = description;
+        }
+        
+        @Override
+        public boolean test(final Map.Entry<ResourceLocation, IRecipe<?>> recipe) {
+        
+            return this.delegate.test(recipe.getValue());
+        }
+    
+        String description() {
+            
+            return this.description;
+        }
+    }
+    
+    private static final class RecipeIterator implements PrimitiveIterator.OfLong {
+        
+        private final int size;
+        private final int half;
+        
+        private int currentLeft;
+        private int currentRight;
+        private boolean kill;
+        
+        RecipeIterator(final int size) {
+            
+            this.size = size;
+            this.half = (int) Math.ceil(((double) this.size) / 2.0); // If size is odd, then we will have a duplicate rather than potentially "forgetting" a pairing.
+            this.currentLeft = 0;
+            this.currentRight = this.half;
+            this.kill = false;
+        }
+        
+        @Override
+        public long nextLong() {
+        
+            if (this.kill) throw new NoSuchElementException();
+            
+            final long current = make(this.currentLeft, this.currentRight);
+            if (++this.currentRight >= this.size) {
+                if (++this.currentLeft >= this.half) this.kill = true;
+                this.currentRight = this.half;
+            }
+            
+            return current;
+        }
+        
+        @Override
+        public boolean hasNext() {
+        
+            return !this.kill;
+        }
+    
+        static long make(final int left, final int right) {
+            
+            return (((long) left) << 32L) | ((long) right);
+        }
+        
+        static int first(final long val) {
+            
+            return (int) (val >> 32L);
+        }
+        
+        static int second(final long val) {
+            
+            return (int) val;
+        }
+    }
+    
+    private static final ExecutorService OFF_THREAD_SERVICE = Executors.newFixedThreadPool(1, r -> {
+        
+        final Thread t = new Thread(r, CraftTweaker.MODID + ":conflict_resolution_thread");
+        t.setDaemon(true); // We don't want to prevent MC from shutting down if this thread is still processing
+        t.setContextClassLoader(ConflictCommands.class.getClassLoader());
+        return t;
+    });
+    
+    private ConflictCommands() {}
+    
+    public static void registerConflictCommands(final TriConsumer<LiteralArgumentBuilder<CommandSource>, String, String> registerCustomCommand) {
+    
+        final Function<IRecipeManager, DescriptiveFilter> managerFilterMaker = manager -> {
+            
+            final IRecipeType<?> type = manager.getRecipeType();
+            return new DescriptiveFilter(it -> it.getType() == type, " for type " + manager.getCommandString());
+        };
+        
+        final Function<ItemStack, DescriptiveFilter> stackFilterMaker = hand ->
+                new DescriptiveFilter(it -> compareStacks(it.getRecipeOutput(), hand), " for output " + new MCItemStack(hand).getCommandString());
+        
+        registerCustomCommand.accept(
+                Commands.literal("conflicts")
+                        .then(Commands.argument("type", CTRecipeTypeArgument.INSTANCE)
+                                .executes(context -> ConflictCommands.conflicts(
+                                        context.getSource().asPlayer(),
+                                        managerFilterMaker.apply(context.getArgument("type", IRecipeManager.class))
+                                )))
+                        .then(Commands.literal("hand")
+                                .executes(context -> ConflictCommands.conflicts(
+                                        context.getSource().asPlayer(),
+                                        stackFilterMaker.apply(context.getSource().asPlayer().getHeldItemMainhand())
+                                )))
+                        .executes(context -> ConflictCommands.conflicts(context.getSource().asPlayer(), new DescriptiveFilter(it -> true, ""))),
+                "conflicts",
+                "Identifies and reports conflicts between various recipes"
+        );
+    }
+
+    private static int conflicts(final PlayerEntity player, final DescriptiveFilter filter) {
+    
+        CommandUtilities.send(
+                // TODO("Translation text component")
+                new StringTextComponent(String.format("Conflict testing%s has begun: ", filter.description()))
+                        .mergeStyle(TextFormatting.GREEN)
+                        .append(new StringTextComponent("do not /reload the server or quit the world in the meantime").mergeStyle(TextFormatting.RED)),
+                player
+        );
+        
+        runConflicts(player, player.world.getRecipeManager(), filter);
+        
+        return 0;
+    }
+    
+    private static void runConflicts(final PlayerEntity player, final RecipeManager manager, final DescriptiveFilter filter) {
+        
+        final LogicalSide side = EffectiveSide.get();
+        final Map<IRecipeType<?>, Map<ResourceLocation, IRecipe<?>>> recipes = deepCopy(manager.recipes, filter);
+        CompletableFuture.supplyAsync(() -> computeConflicts(recipes), OFF_THREAD_SERVICE)
+                .thenAcceptAsync(message -> dispatchMessageTo(message, player, side), OFF_THREAD_SERVICE);
+    }
+    
+    private static Map<IRecipeType<?>, Map<ResourceLocation, IRecipe<?>>> deepCopy(final Map<IRecipeType<?>, Map<ResourceLocation, IRecipe<?>>> original, final DescriptiveFilter filter) {
+        
+        final Map<IRecipeType<?>, Map<ResourceLocation, IRecipe<?>>> clone = new HashMap<>();
+        
+        original.forEach((type, map) -> {
+            
+            final Map<ResourceLocation, IRecipe<?>> cloneMap = clone.computeIfAbsent(type, it -> new HashMap<>());
+            map.entrySet().stream().filter(filter).forEach(it -> cloneMap.put(it.getKey(), it.getValue()));
+        });
+        
+        return clone;
+    }
+    
+    private static String computeConflicts(final Map<IRecipeType<?>, Map<ResourceLocation, IRecipe<?>>> recipes) {
+        
+        return recipes.entrySet()
+                .stream()
+                .flatMap(ConflictCommands::computeConflictsFor)
+                .collect(Collectors.joining("\n- ", "- ", ""));
+    }
+    
+    private static Stream<String> computeConflictsFor(final Map.Entry<IRecipeType<?>, Map<ResourceLocation, IRecipe<?>>> entry) {
+        
+        final IRecipeManager manager = RecipeTypeBracketHandler.getOrDefault(entry.getKey());
+        
+        if (manager == null) return Stream.of();
+        
+        final List<Map.Entry<ResourceLocation, IRecipe<?>>> recipes = new ArrayList<>(entry.getValue().entrySet());
+        final int characteristics = Spliterator.ORDERED | Spliterator.SORTED | Spliterator.NONNULL | Spliterator.IMMUTABLE;
+        
+        return StreamSupport.longStream(Spliterators.spliteratorUnknownSize(new RecipeIterator(recipes.size()), characteristics), false)
+                .filter(it -> conflictsWith(manager, recipes.get(RecipeIterator.first(it)).getValue(), recipes.get(RecipeIterator.second(it)).getValue()))
+                .mapToObj(it -> formatConflict(manager, recipes.get(RecipeIterator.first(it)).getKey(), recipes.get(RecipeIterator.second(it)).getKey()));
+    }
+    
+    private static <T extends IRecipe<?>> boolean conflictsWith(final IRecipeManager manager, final T first, final IRecipe<?> second) {
+        
+        return first != second && CraftTweakerRegistry.getHandlerFor(first).conflictsWith(manager, first, second);
+    }
+    
+    private static String formatConflict(final IRecipeManager manager, final ResourceLocation firstName, final ResourceLocation secondName) {
+        
+        return String.format("Recipes '%s' and '%s' in type '%s' have conflicting inputs", firstName, secondName, manager.getCommandString());
+    }
+    
+    private static void dispatchMessageTo(final String message, final PlayerEntity player, final LogicalSide side) {
+        
+        runOnMainThread(side, () -> {
+            try {
+                CraftTweakerAPI.logDump("- ".equals(message)? "No conflicts identified" : message);
+                CommandUtilities.send(CommandUtilities.color("Conflict testing completed: results are in the log", TextFormatting.GREEN), player);
+            } catch (final Exception e) {
+                
+                try {
+                    
+                    CraftTweakerAPI.logThrowing("An error occurred while reporting conflicts, hopefully it does not happen again", e);
+                } catch (final Exception another) {
+                    
+                    e.addSuppressed(another);
+                    e.printStackTrace(System.err); // It's not going to be useful if the logging throws errors, but at least we can say we tried
+                }
+            }
+        });
+    }
+    
+    private static void runOnMainThread(final LogicalSide currentSide, final Runnable runnable) {
+        
+        final ThreadTaskExecutor<?> executor = LogicalSidedProvider.WORKQUEUE.get(currentSide);
+        
+        if (!executor.isOnExecutionThread()) {
+            
+            executor.deferTask(runnable);
+        } else {
+            
+            runnable.run();
+        }
+    }
+    
+    // TODO("This is a copy of IItemStack#matches written to avoid object creation: find a way to avoid code duplication")
+    private static boolean compareStacks(final ItemStack first, final ItemStack second) {
+        
+        if (first.isEmpty() != second.isEmpty()) return false;
+        if (first.getItem() != second.getItem()) return false;
+        if (first.getCount() > second.getCount()) return false;
+        if (first.getDamage() != second.getDamage()) return false;
+        
+        final CompoundNBT firstTag = first.getTag();
+        final CompoundNBT secondTag = second.getTag();
+        
+        // Note: different from original
+        if (firstTag == null) return true;
+        if (secondTag == null) return false;
+        // The original code checks if they are both null and returns true if so, otherwise it converts both of them to
+        // MapData and then checks again if the first tag is null. The only possibility is if firstTag is actually null,
+        // so we can simplify the check. Also, if the first tag is not null, the second tag cannot be null, otherwise
+        // there is no match. We can account for that too.
+        
+        return firstTag.equals(secondTag);
+    }
+}

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/ConflictCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/ConflictCommands.java
@@ -7,7 +7,7 @@ import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.brackets.RecipeTypeBracketHandler;
 import com.blamejared.crafttweaker.impl.commands.CTRecipeTypeArgument;
 import com.blamejared.crafttweaker.impl.commands.CommandUtilities;
-import com.blamejared.crafttweaker.impl.item.MCItemStack;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
@@ -16,7 +16,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.item.crafting.RecipeManager;
-import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.concurrent.ThreadTaskExecutor;
 import net.minecraft.util.text.StringTextComponent;
@@ -139,7 +138,7 @@ public final class ConflictCommands {
         };
         
         final Function<ItemStack, DescriptiveFilter> stackFilterMaker = hand ->
-                new DescriptiveFilter(it -> compareStacks(it.getRecipeOutput(), hand), " for output " + new MCItemStack(hand).getCommandString());
+                new DescriptiveFilter(it -> ItemStackHelper.areStacksTheSame(it.getRecipeOutput(), hand), " for output " + ItemStackHelper.getCommandString(hand));
         
         registerCustomCommand.accept(
                 Commands.literal("conflicts")
@@ -258,27 +257,5 @@ public final class ConflictCommands {
             
             runnable.run();
         }
-    }
-    
-    // TODO("This is a copy of IItemStack#matches written to avoid object creation: find a way to avoid code duplication")
-    private static boolean compareStacks(final ItemStack first, final ItemStack second) {
-        
-        if (first.isEmpty() != second.isEmpty()) return false;
-        if (first.getItem() != second.getItem()) return false;
-        if (first.getCount() > second.getCount()) return false;
-        if (first.getDamage() != second.getDamage()) return false;
-        
-        final CompoundNBT firstTag = first.getTag();
-        final CompoundNBT secondTag = second.getTag();
-        
-        // Note: different from original
-        if (firstTag == null) return true;
-        if (secondTag == null) return false;
-        // The original code checks if they are both null and returns true if so, otherwise it converts both of them to
-        // MapData and then checks again if the first tag is null. The only possibility is if firstTag is actually null,
-        // so we can simplify the check. Also, if the first tag is not null, the second tag cannot be null, otherwise
-        // there is no match. We can account for that too.
-        
-        return firstTag.equals(secondTag);
     }
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/HandCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/HandCommands.java
@@ -6,6 +6,7 @@ import com.blamejared.crafttweaker.impl.commands.CommandCallerPlayer;
 import com.blamejared.crafttweaker.impl.commands.CommandUtilities;
 import com.blamejared.crafttweaker.impl.data.MapData;
 import com.blamejared.crafttweaker.impl.fluid.MCFluidStackMutable;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
 import com.blamejared.crafttweaker.impl.tag.MCTag;
 import com.blamejared.crafttweaker.impl.tag.manager.TagManager;
@@ -161,7 +162,7 @@ public final class HandCommands {
     // <editor-fold desc="CT Functions">
     private static void sendBasicItemInformation(final PlayerEntity player, final ItemStack target) {
         
-        final String output = new MCItemStackMutable(target).getCommandString();
+        final String output = ItemStackHelper.getCommandString(target);
         sendCopyingHand(player, "Item", output);
     }
     

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/InventoryCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/InventoryCommands.java
@@ -3,6 +3,7 @@ package com.blamejared.crafttweaker.impl.commands.crafttweaker;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.impl.commands.CTCommands;
 import com.blamejared.crafttweaker.impl.commands.CommandUtilities;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
 import com.blamejared.crafttweaker.impl.tag.MCTag;
 import com.blamejared.crafttweaker.impl.tag.manager.TagManagerItem;
@@ -42,7 +43,7 @@ public final class InventoryCommands {
                 final String inventoryContents = IntStream.range(0, inventory.getSlots())
                         .mapToObj(inventory::getStackInSlot)
                         .filter(it -> !it.isEmpty())
-                        .map(it -> Pair.of(new MCItemStackMutable(it).getCommandString(), TagManagerItem.INSTANCE.getAllTagsFor(it.getItem())))
+                        .map(it -> Pair.of(ItemStackHelper.getCommandString(it), TagManagerItem.INSTANCE.getAllTagsFor(it.getItem())))
                         .map(it -> it.getFirst() + '\n' + stringify(it.getSecond()))
                         .collect(Collectors.joining("\n", "Inventory item tags\n", ""));
                 

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/ConflictCommand.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/ConflictCommand.java
@@ -148,7 +148,7 @@ public final class ConflictCommand {
     
     private static <T extends IRecipe<?>> boolean conflictsWith(final IRecipeManager manager, final T first, final IRecipe<?> second) {
         
-        return first != second && CraftTweakerRegistry.getHandlerFor(first).isThereConflictBetween(manager, first, second);
+        return first != second && CraftTweakerRegistry.getHandlerFor(first).doesConflict(manager, first, second);
     }
     
     private static String formatConflict(final IRecipeManager manager, final ResourceLocation firstName, final ResourceLocation secondName) {

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/ConflictCommand.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/ConflictCommand.java
@@ -131,7 +131,7 @@ public final class ConflictCommand {
     
     private static <T extends IRecipe<?>> boolean conflictsWith(final IRecipeManager manager, final T first, final IRecipe<?> second) {
         
-        return first != second && CraftTweakerRegistry.getHandlerFor(first).conflictsWith(manager, first, second);
+        return first != second && CraftTweakerRegistry.getHandlerFor(first).isThereConflictBetween(manager, first, second);
     }
     
     private static String formatConflict(final IRecipeManager manager, final ResourceLocation firstName, final ResourceLocation secondName) {

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/DescriptiveFilter.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/DescriptiveFilter.java
@@ -1,0 +1,50 @@
+package com.blamejared.crafttweaker.impl.commands.crafttweaker.conflict;
+
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.ResourceLocation;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+final class DescriptiveFilter implements Predicate<Map.Entry<ResourceLocation, IRecipe<?>>> {
+    
+    private final Predicate<IRecipe<?>> delegate;
+    private final String description;
+    
+    private DescriptiveFilter(final Predicate<IRecipe<?>> delegate, final String description) {
+        
+        this.delegate = delegate;
+        this.description = description;
+    }
+    
+    static DescriptiveFilter of() {
+        
+        return new DescriptiveFilter(it -> true, "");
+    }
+    
+    static DescriptiveFilter of(final IRecipeManager manager) {
+        
+        final IRecipeType<?> type = manager.getRecipeType();
+        return new DescriptiveFilter(it -> it.getType() == type, " for type " + manager.getCommandString());
+    }
+    
+    static DescriptiveFilter of(final ItemStack stack) {
+        
+        return new DescriptiveFilter(it -> ItemStackHelper.areStacksTheSame(it.getRecipeOutput(), stack), " for output " + ItemStackHelper.getCommandString(stack));
+    }
+    
+    @Override
+    public boolean test(final Map.Entry<ResourceLocation, IRecipe<?>> recipe) {
+        
+        return this.delegate.test(recipe.getValue());
+    }
+    
+    String description() {
+        
+        return this.description;
+    }
+}

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/RecipeLongIterator.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/RecipeLongIterator.java
@@ -48,7 +48,7 @@ final class RecipeLongIterator implements PrimitiveIterator.OfLong {
     
     long estimateLength() {
         
-        return (long) Math.ceil((double) (((long) this.size) * (((long) this.size) - 1L)) / 2.0D);
+        return ((long) this.size * ((long) this.size - 1L)) / 2L;
     }
     
     static long make(final int left, final int right) {

--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/RecipeLongIterator.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/conflict/RecipeLongIterator.java
@@ -1,0 +1,68 @@
+package com.blamejared.crafttweaker.impl.commands.crafttweaker.conflict;
+
+import java.util.NoSuchElementException;
+import java.util.PrimitiveIterator;
+
+final class RecipeLongIterator implements PrimitiveIterator.OfLong {
+    
+    private final int size;
+    
+    private int currentLeft;
+    private int currentRight;
+    private boolean kill;
+    
+    RecipeLongIterator(final int size) {
+        
+        this.size = size;
+        this.currentLeft = 0;
+        this.currentRight = this.currentLeft + 1;
+        this.kill = false;
+    }
+    
+    @Override
+    public long nextLong() {
+        
+        if (this.kill) throw new NoSuchElementException();
+        
+        final long current = make(this.currentLeft, this.currentRight);
+        
+        ++this.currentRight;
+        
+        if (this.currentRight >= this.size) {
+            
+            ++this.currentLeft;
+            
+            if (this.currentLeft >= this.size - 1) this.kill = true;
+            
+            this.currentRight = this.currentLeft + 1;
+        }
+        
+        return current;
+    }
+    
+    @Override
+    public boolean hasNext() {
+        
+        return !this.kill;
+    }
+    
+    long estimateLength() {
+        
+        return (long) Math.ceil((double) (((long) this.size) * (((long) this.size) - 1L)) / 2.0D);
+    }
+    
+    static long make(final int left, final int right) {
+        
+        return (((long) left) << 32L) | ((long) right);
+    }
+    
+    static int first(final long val) {
+        
+        return (int) (val >> 32L);
+    }
+    
+    static int second(final long val) {
+        
+        return (int) val;
+    }
+}

--- a/src/main/java/com/blamejared/crafttweaker/impl/events/CTClientEventHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/events/CTClientEventHandler.java
@@ -6,6 +6,7 @@ import com.blamejared.crafttweaker.api.entity.NamePlateResult;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.item.tooltip.ITooltipFunction;
 import com.blamejared.crafttweaker.impl.entity.MCEntityType;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
 import com.blamejared.crafttweaker.impl.util.text.MCTextComponent;
 import net.minecraft.entity.Entity;
@@ -67,7 +68,7 @@ public class CTClientEventHandler {
                                 String.format(
                                         "Unable to run one of the tooltip functions for %s on %s due to an error (for experts, refer to %s)",
                                         ingredient.getCommandString(),
-                                        new MCItemStackMutable(e.getItemStack()).getCommandString(),
+                                        ItemStackHelper.getCommandString(e.getItemStack()),
                                         function.getClass().getName()
                                 ),
                                 exception

--- a/src/main/java/com/blamejared/crafttweaker/impl/helper/IngredientHelper.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/helper/IngredientHelper.java
@@ -1,0 +1,49 @@
+package com.blamejared.crafttweaker.impl.helper;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class IngredientHelper {
+    
+    public static boolean canConflict(final Ingredient a, final Ingredient b) {
+        
+        return a == b || (a.getMatchingStacks().length == 0 && b.getMatchingStacks().length == 0) || !findIntersection(a, b).isEmpty();
+    }
+    
+    public static List<ItemStack> findIntersection(final Ingredient a, final Ingredient b) {
+        
+        if (a == Ingredient.EMPTY || b == Ingredient.EMPTY) return Collections.emptyList();
+    
+        final ItemStack[] aStacks = a.getMatchingStacks();
+        final ItemStack[] bStacks = b.getMatchingStacks();
+    
+        if (a == b) return Arrays.asList(aStacks);
+        
+        List<ItemStack> intersection = null;
+        
+        // Empiric testing shows that the naive double-for-loop is very efficient for small arrays rather than more
+        // specialized data structures, which have more costs associated with them
+        for (final ItemStack aStack : aStacks) {
+            
+            for (final ItemStack bStack : bStacks) {
+                
+                if (ItemStackHelper.areStacksTheSame(aStack, bStack)) {
+                    
+                    if (intersection == null) {
+                        
+                        intersection = new ArrayList<>();
+                    }
+                    
+                    intersection.add(aStack);
+                }
+            }
+        }
+        
+        return intersection == null? Collections.emptyList() : intersection;
+    }
+}

--- a/src/main/java/com/blamejared/crafttweaker/impl/helper/ItemStackHelper.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/helper/ItemStackHelper.java
@@ -8,18 +8,26 @@ import net.minecraft.nbt.CompoundNBT;
 public final class ItemStackHelper {
     
     public static String getCommandString(final ItemStack stack) {
+        
+        return getCommandString(stack, false);
+    }
+    
+    public static String getCommandString(final ItemStack stack, final boolean mutable) {
     
         final StringBuilder sb = new StringBuilder("<item:");
         sb.append(stack.getItem().getRegistryName());
         sb.append('>');
     
         if(stack.getTag() != null) {
+            
             MapData data = (MapData) NBTConverter.convert(stack.getTag()).copyInternal();
             //Damage is special case, if we have more special cases we can handle them here.
             if(stack.getItem().isDamageable()) {
+                
                 data.remove("Damage");
             }
             if(!data.isEmpty()) {
+                
                 sb.append(".withTag(");
                 sb.append(data.asString());
                 sb.append(')');
@@ -27,14 +35,20 @@ public final class ItemStackHelper {
         }
     
         if(stack.getDamage() > 0) {
+            
             sb.append(".withDamage(").append(stack.getDamage()).append(')');
         }
     
-        if(!stack.isEmpty()) {
-            if(stack.getCount() != 1) {
-                sb.append(" * ").append(stack.getCount());
-            }
+        if(!stack.isEmpty() && stack.getCount() != 1) {
+            
+            sb.append(" * ").append(stack.getCount());
         }
+        
+        if (mutable) {
+            
+            sb.append(".mutable()");
+        }
+        
         return sb.toString();
     }
     

--- a/src/main/java/com/blamejared/crafttweaker/impl/helper/ItemStackHelper.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/helper/ItemStackHelper.java
@@ -1,0 +1,63 @@
+package com.blamejared.crafttweaker.impl.helper;
+
+import com.blamejared.crafttweaker.api.data.NBTConverter;
+import com.blamejared.crafttweaker.impl.data.MapData;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+
+public final class ItemStackHelper {
+    
+    public static String getCommandString(final ItemStack stack) {
+    
+        final StringBuilder sb = new StringBuilder("<item:");
+        sb.append(stack.getItem().getRegistryName());
+        sb.append('>');
+    
+        if(stack.getTag() != null) {
+            MapData data = (MapData) NBTConverter.convert(stack.getTag()).copyInternal();
+            //Damage is special case, if we have more special cases we can handle them here.
+            if(stack.getItem().isDamageable()) {
+                data.remove("Damage");
+            }
+            if(!data.isEmpty()) {
+                sb.append(".withTag(");
+                sb.append(data.asString());
+                sb.append(')');
+            }
+        }
+    
+        if(stack.getDamage() > 0) {
+            sb.append(".withDamage(").append(stack.getDamage()).append(')');
+        }
+    
+        if(!stack.isEmpty()) {
+            if(stack.getCount() != 1) {
+                sb.append(" * ").append(stack.getCount());
+            }
+        }
+        return sb.toString();
+    }
+    
+    // TODO("This is a copy of IItemStack#matches written to avoid object creation: find a way to avoid code duplication")
+    public static boolean areStacksTheSame(final ItemStack first, final ItemStack second) {
+        
+        if (first.isEmpty() != second.isEmpty()) return false;
+        if (first.getItem() != second.getItem()) return false;
+        if (first.getCount() > second.getCount()) return false;
+        if (first.getDamage() != second.getDamage()) return false;
+        
+        final CompoundNBT firstTag = first.getTag();
+        final CompoundNBT secondTag = second.getTag();
+    
+        // Note: different from original
+        if (firstTag == null) return true;
+        if (secondTag == null) return false;
+        // The original code checks if they are both null and returns true if so, otherwise it converts both of them to
+        // MapData and then checks again if the first tag is null. The only possibility is if firstTag is actually null,
+        // so we can simplify the check. Also, if the first tag is not null, the second tag cannot be null, otherwise
+        // there is no match. We can account for that too.
+        
+        return firstTag.equals(secondTag);
+    }
+    
+}

--- a/src/main/java/com/blamejared/crafttweaker/impl/helper/ThreadingHelper.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/helper/ThreadingHelper.java
@@ -1,0 +1,21 @@
+package com.blamejared.crafttweaker.impl.helper;
+
+import net.minecraft.util.concurrent.ThreadTaskExecutor;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.LogicalSidedProvider;
+
+public final class ThreadingHelper {
+    
+    public static void runOnMainThread(final LogicalSide currentSide, final Runnable runnable) {
+        
+        final ThreadTaskExecutor<?> executor = LogicalSidedProvider.WORKQUEUE.get(currentSide);
+    
+        if (!executor.isOnExecutionThread()) {
+        
+            executor.deferTask(runnable);
+        } else {
+        
+            runnable.run();
+        }
+    }
+}

--- a/src/main/java/com/blamejared/crafttweaker/impl/item/MCItemStack.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/item/MCItemStack.java
@@ -1,11 +1,11 @@
 package com.blamejared.crafttweaker.impl.item;
 
 import com.blamejared.crafttweaker.api.data.IData;
-import com.blamejared.crafttweaker.api.data.NBTConverter;
 import com.blamejared.crafttweaker.api.ingredient.PartialNBTIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.util.AttributeUtil;
 import com.blamejared.crafttweaker.impl.data.MapData;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.util.EnchantmentUtil;
 import com.blamejared.crafttweaker.impl.util.text.MCTextComponent;
 import net.minecraft.enchantment.Enchantment;
@@ -137,33 +137,7 @@ public class MCItemStack implements IItemStack {
     @Override
     public String getCommandString() {
         
-        final StringBuilder sb = new StringBuilder("<item:");
-        sb.append(getInternal().getItem().getRegistryName());
-        sb.append(">");
-        
-        if(getInternal().getTag() != null) {
-            MapData data = (MapData) NBTConverter.convert(getInternal().getTag()).copyInternal();
-            //Damage is special case, if we have more special cases we can handle them here.
-            if(getInternal().getItem().isDamageable()) {
-                data.remove("Damage");
-            }
-            if(!data.isEmpty()) {
-                sb.append(".withTag(");
-                sb.append(data.asString());
-                sb.append(")");
-            }
-        }
-        
-        if(getInternal().getDamage() > 0) {
-            sb.append(".withDamage(").append(getInternal().getDamage()).append(")");
-        }
-        
-        if(!isEmpty()) {
-            if(getAmount() != 1) {
-                sb.append(" * ").append(getAmount());
-            }
-        }
-        return sb.toString();
+        return ItemStackHelper.getCommandString(this.getInternal());
     }
     
     @Override

--- a/src/main/java/com/blamejared/crafttweaker/impl/item/MCItemStackMutable.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/item/MCItemStackMutable.java
@@ -2,11 +2,11 @@ package com.blamejared.crafttweaker.impl.item;
 
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker.api.data.IData;
-import com.blamejared.crafttweaker.api.data.NBTConverter;
 import com.blamejared.crafttweaker.api.ingredient.PartialNBTIngredient;
 import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.util.AttributeUtil;
 import com.blamejared.crafttweaker.impl.data.MapData;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.util.EnchantmentUtil;
 import com.blamejared.crafttweaker.impl.util.text.MCTextComponent;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
@@ -138,32 +138,7 @@ public class MCItemStackMutable implements IItemStack {
     @Override
     public String getCommandString() {
         
-        final StringBuilder sb = new StringBuilder("<item:");
-        sb.append(getInternal().getItem().getRegistryName());
-        sb.append(">");
-        
-        if(getInternal().getTag() != null) {
-            MapData data = (MapData) NBTConverter.convert(getInternal().getTag()).copyInternal();
-            //Damage is special case, if we have more special cases we can handle them here.
-            if(getInternal().getItem().isDamageable()) {
-                data.remove("Damage");
-            }
-            if(!data.isEmpty()) {
-                sb.append(".withTag(");
-                sb.append(data.asString());
-                sb.append(")");
-            }
-        }
-        
-        if(getInternal().getDamage() > 0) {
-            sb.append(".withDamage(").append(getInternal().getDamage()).append(")");
-        }
-        if(!isEmpty()) {
-            if(getAmount() != 1) {
-                sb.append(" * ").append(getAmount());
-            }
-        }
-        return sb.toString();
+        return ItemStackHelper.getCommandString(this.getInternal());
     }
     
     @Override

--- a/src/main/java/com/blamejared/crafttweaker/impl/item/MCItemStackMutable.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/item/MCItemStackMutable.java
@@ -138,7 +138,7 @@ public class MCItemStackMutable implements IItemStack {
     @Override
     public String getCommandString() {
         
-        return ItemStackHelper.getCommandString(this.getInternal());
+        return ItemStackHelper.getCommandString(this.getInternal(), true);
     }
     
     @Override

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapedRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapedRecipeHandler.java
@@ -6,8 +6,10 @@ import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.recipes.ReplacementHandlerHelper;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.recipes.CTRecipeShaped;
+import com.blamejared.crafttweaker.impl.recipes.helper.CraftingTableRecipeConflictChecker;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.Arrays;
@@ -25,7 +27,7 @@ public final class CTShapedRecipeHandler implements IRecipeHandler<CTRecipeShape
         return String.format(
                 "craftingTable.addShaped(%s, %s, %s%s);",
                 StringUtils.quoteAndEscape(recipe.getId()),
-                new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
                 Arrays.stream(recipe.getCtIngredients())
                         .map(row -> Arrays.stream(row)
                                 .map(IIngredient::getCommandString)
@@ -51,6 +53,12 @@ public final class CTShapedRecipeHandler implements IRecipeHandler<CTRecipeShape
                         recipe.getFunction()
                 )
         );
+    }
+    
+    @Override
+    public boolean conflictsWith(final IRecipeManager manager, final CTRecipeShaped firstRecipe, final IRecipe<?> secondRecipe) {
+        
+        return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }
     
     private IIngredient[] flatten(final IIngredient[][] ingredients, final int width, final int height) {

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapedRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapedRecipeHandler.java
@@ -55,7 +55,7 @@ public final class CTShapedRecipeHandler implements IRecipeHandler<CTRecipeShape
     }
     
     @Override
-    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final CTRecipeShaped firstRecipe, final U secondRecipe) {
+    public <U extends IRecipe<?>> boolean doesConflict(final IRecipeManager manager, final CTRecipeShaped firstRecipe, final U secondRecipe) {
         
         return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapedRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapedRecipeHandler.java
@@ -27,7 +27,7 @@ public final class CTShapedRecipeHandler implements IRecipeHandler<CTRecipeShape
         return String.format(
                 "craftingTable.addShaped(%s, %s, %s%s);",
                 StringUtils.quoteAndEscape(recipe.getId()),
-                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
+                recipe.getCtOutput().getCommandString(),
                 Arrays.stream(recipe.getCtIngredients())
                         .map(row -> Arrays.stream(row)
                                 .map(IIngredient::getCommandString)

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapedRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapedRecipeHandler.java
@@ -6,7 +6,6 @@ import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.recipes.ReplacementHandlerHelper;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.recipes.CTRecipeShaped;
 import com.blamejared.crafttweaker.impl.recipes.helper.CraftingTableRecipeConflictChecker;
 import net.minecraft.item.crafting.IRecipe;
@@ -56,7 +55,7 @@ public final class CTShapedRecipeHandler implements IRecipeHandler<CTRecipeShape
     }
     
     @Override
-    public boolean conflictsWith(final IRecipeManager manager, final CTRecipeShaped firstRecipe, final IRecipe<?> secondRecipe) {
+    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final CTRecipeShaped firstRecipe, final U secondRecipe) {
         
         return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapelessRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapelessRecipeHandler.java
@@ -47,7 +47,7 @@ public final class CTShapelessRecipeHandler implements IRecipeHandler<CTRecipeSh
     }
     
     @Override
-    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final CTRecipeShapeless firstRecipe, final U secondRecipe) {
+    public <U extends IRecipe<?>> boolean doesConflict(final IRecipeManager manager, final CTRecipeShapeless firstRecipe, final U secondRecipe) {
         
         return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapelessRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapelessRecipeHandler.java
@@ -27,7 +27,7 @@ public final class CTShapelessRecipeHandler implements IRecipeHandler<CTRecipeSh
         return String.format(
                 "craftingTable.addShapeless(%s, %s, %s%s);",
                 StringUtils.quoteAndEscape(recipe.getId()),
-                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
+                recipe.getCtOutput().getCommandString(),
                 Arrays.stream(recipe.getCtIngredients())
                         .map(IIngredient::getCommandString)
                         .collect(Collectors.joining(", ", "[", "]")),

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapelessRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapelessRecipeHandler.java
@@ -6,8 +6,10 @@ import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.recipes.ReplacementHandlerHelper;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.recipes.CTRecipeShapeless;
+import com.blamejared.crafttweaker.impl.recipes.helper.CraftingTableRecipeConflictChecker;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.ResourceLocation;
 
 import java.util.Arrays;
@@ -25,7 +27,7 @@ public final class CTShapelessRecipeHandler implements IRecipeHandler<CTRecipeSh
         return String.format(
                 "craftingTable.addShapeless(%s, %s, %s%s);",
                 StringUtils.quoteAndEscape(recipe.getId()),
-                new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
                 Arrays.stream(recipe.getCtIngredients())
                         .map(IIngredient::getCommandString)
                         .collect(Collectors.joining(", ", "[", "]")),
@@ -43,6 +45,12 @@ public final class CTShapelessRecipeHandler implements IRecipeHandler<CTRecipeSh
                 rules,
                 newIngredients -> id -> new CTRecipeShapeless(id.getPath(), recipe.getCtOutput(), newIngredients, recipe.getFunction())
         );
+    }
+    
+    @Override
+    public boolean conflictsWith(final IRecipeManager manager, final CTRecipeShapeless firstRecipe, final IRecipe<?> secondRecipe) {
+        
+        return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }
     
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapelessRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/crafttweaker/CTShapelessRecipeHandler.java
@@ -6,7 +6,6 @@ import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.recipes.ReplacementHandlerHelper;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.blamejared.crafttweaker.impl.recipes.CTRecipeShapeless;
 import com.blamejared.crafttweaker.impl.recipes.helper.CraftingTableRecipeConflictChecker;
 import net.minecraft.item.crafting.IRecipe;
@@ -48,7 +47,7 @@ public final class CTShapelessRecipeHandler implements IRecipeHandler<CTRecipeSh
     }
     
     @Override
-    public boolean conflictsWith(final IRecipeManager manager, final CTRecipeShapeless firstRecipe, final IRecipe<?> secondRecipe) {
+    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final CTRecipeShapeless firstRecipe, final U secondRecipe) {
         
         return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/CookingRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/CookingRecipeHandler.java
@@ -5,7 +5,8 @@ import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.helper.IngredientHelper;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.item.ItemStack;
@@ -13,6 +14,7 @@ import net.minecraft.item.crafting.AbstractCookingRecipe;
 import net.minecraft.item.crafting.BlastingRecipe;
 import net.minecraft.item.crafting.CampfireCookingRecipe;
 import net.minecraft.item.crafting.FurnaceRecipe;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.SmokingRecipe;
@@ -37,7 +39,7 @@ public final class CookingRecipeHandler implements IRecipeHandler<AbstractCookin
     }
     
     private static final Map<IRecipeType<?>, Pair<String, CookingRecipeFactory<?>>> LOOKUP = ImmutableMap
-            .<IRecipeType<?>, Pair<String, CookingRecipeFactory<?>>> builder()
+            .<IRecipeType<?>, Pair<String, CookingRecipeFactory<?>>>builder()
             .put(IRecipeType.BLASTING, Pair.of("blastFurnace", BlastingRecipe::new))
             .put(IRecipeType.CAMPFIRE_COOKING, Pair.of("campfire", CampfireCookingRecipe::new))
             .put(IRecipeType.SMELTING, Pair.of("furnace", FurnaceRecipe::new))
@@ -51,7 +53,7 @@ public final class CookingRecipeHandler implements IRecipeHandler<AbstractCookin
                 "%s.addRecipe(%s, %s, %s, %s, %s);",
                 LOOKUP.get(recipe.getType()).getFirst(),
                 StringUtils.quoteAndEscape(recipe.getId()),
-                new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
                 IIngredient.fromIngredient(recipe.getIngredients().get(0)).getCommandString(),
                 recipe.getExperience(),
                 recipe.getCookTime()
@@ -67,4 +69,9 @@ public final class CookingRecipeHandler implements IRecipeHandler<AbstractCookin
                         .create(id, recipe.getGroup(), input, recipe.getRecipeOutput(), recipe.getExperience(), recipe.getCookTime()));
     }
     
+    @Override
+    public boolean conflictsWith(final IRecipeManager manager, final AbstractCookingRecipe firstRecipe, final IRecipe<?> secondRecipe) {
+        
+        return IngredientHelper.canConflict(firstRecipe.getIngredients().get(0), secondRecipe.getIngredients().get(0));
+    }
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/CookingRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/CookingRecipeHandler.java
@@ -70,7 +70,7 @@ public final class CookingRecipeHandler implements IRecipeHandler<AbstractCookin
     }
     
     @Override
-    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final AbstractCookingRecipe firstRecipe, final U secondRecipe) {
+    public <U extends IRecipe<?>> boolean doesConflict(final IRecipeManager manager, final AbstractCookingRecipe firstRecipe, final U secondRecipe) {
         
         return IngredientHelper.canConflict(firstRecipe.getIngredients().get(0), secondRecipe.getIngredients().get(0));
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/CookingRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/CookingRecipeHandler.java
@@ -70,7 +70,7 @@ public final class CookingRecipeHandler implements IRecipeHandler<AbstractCookin
     }
     
     @Override
-    public boolean conflictsWith(final IRecipeManager manager, final AbstractCookingRecipe firstRecipe, final IRecipe<?> secondRecipe) {
+    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final AbstractCookingRecipe firstRecipe, final U secondRecipe) {
         
         return IngredientHelper.canConflict(firstRecipe.getIngredients().get(0), secondRecipe.getIngredients().get(0));
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapedRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapedRecipeHandler.java
@@ -54,7 +54,7 @@ public final class ShapedRecipeHandler implements IRecipeHandler<ShapedRecipe> {
     }
     
     @Override
-    public boolean conflictsWith(final IRecipeManager manager, final ShapedRecipe firstRecipe, final IRecipe<?> secondRecipe) {
+    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final ShapedRecipe firstRecipe, final U secondRecipe) {
         
         return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapedRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapedRecipeHandler.java
@@ -6,7 +6,9 @@ import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.recipes.ReplacementHandlerHelper;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
+import com.blamejared.crafttweaker.impl.recipes.helper.CraftingTableRecipeConflictChecker;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.ShapedRecipe;
 import net.minecraft.util.NonNullList;
@@ -28,7 +30,7 @@ public final class ShapedRecipeHandler implements IRecipeHandler<ShapedRecipe> {
         return String.format(
                 "craftingTable.addShaped(%s, %s, %s);",
                 StringUtils.quoteAndEscape(recipe.getId()),
-                new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
                 IntStream.range(0, recipe.getRecipeHeight())
                         .mapToObj(y -> IntStream.range(0, recipe.getRecipeWidth())
                                 .mapToObj(x -> ingredients.get(y * recipe.getRecipeWidth() + x))
@@ -49,6 +51,12 @@ public final class ShapedRecipeHandler implements IRecipeHandler<ShapedRecipe> {
                 rules,
                 newIngredients -> id -> new ShapedRecipe(id, recipe.getGroup(), recipe.getRecipeWidth(), recipe.getRecipeHeight(), newIngredients, recipe.getRecipeOutput())
         );
+    }
+    
+    @Override
+    public boolean conflictsWith(final IRecipeManager manager, final ShapedRecipe firstRecipe, final IRecipe<?> secondRecipe) {
+        
+        return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }
     
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapedRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapedRecipeHandler.java
@@ -54,7 +54,7 @@ public final class ShapedRecipeHandler implements IRecipeHandler<ShapedRecipe> {
     }
     
     @Override
-    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final ShapedRecipe firstRecipe, final U secondRecipe) {
+    public <U extends IRecipe<?>> boolean doesConflict(final IRecipeManager manager, final ShapedRecipe firstRecipe, final U secondRecipe) {
         
         return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapelessRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapelessRecipeHandler.java
@@ -48,7 +48,7 @@ public final class ShapelessRecipeHandler implements IRecipeHandler<ShapelessRec
     }
     
     @Override
-    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final ShapelessRecipe firstRecipe, final U secondRecipe) {
+    public <U extends IRecipe<?>> boolean doesConflict(final IRecipeManager manager, final ShapelessRecipe firstRecipe, final U secondRecipe) {
     
         return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapelessRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapelessRecipeHandler.java
@@ -6,7 +6,9 @@ import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.recipes.ReplacementHandlerHelper;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
+import com.blamejared.crafttweaker.impl.recipes.helper.CraftingTableRecipeConflictChecker;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.ShapelessRecipe;
 import net.minecraft.util.ResourceLocation;
@@ -25,7 +27,7 @@ public final class ShapelessRecipeHandler implements IRecipeHandler<ShapelessRec
         return String.format(
                 "craftingTable.addShapeless(%s, %s, %s);",
                 StringUtils.quoteAndEscape(recipe.getId()),
-                new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
                 recipe.getIngredients().stream()
                         .map(IIngredient::fromIngredient)
                         .map(IIngredient::getCommandString)
@@ -45,4 +47,9 @@ public final class ShapelessRecipeHandler implements IRecipeHandler<ShapelessRec
         );
     }
     
+    @Override
+    public boolean conflictsWith(final IRecipeManager manager, final ShapelessRecipe firstRecipe, final IRecipe<?> secondRecipe) {
+    
+        return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
+    }
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapelessRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/ShapelessRecipeHandler.java
@@ -48,7 +48,7 @@ public final class ShapelessRecipeHandler implements IRecipeHandler<ShapelessRec
     }
     
     @Override
-    public boolean conflictsWith(final IRecipeManager manager, final ShapelessRecipe firstRecipe, final IRecipe<?> secondRecipe) {
+    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final ShapelessRecipe firstRecipe, final U secondRecipe) {
     
         return CraftingTableRecipeConflictChecker.checkConflicts(manager, firstRecipe, secondRecipe);
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/SmithingRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/SmithingRecipeHandler.java
@@ -46,7 +46,7 @@ public final class SmithingRecipeHandler implements IRecipeHandler<SmithingRecip
     }
     
     @Override
-    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final SmithingRecipe firstRecipe, final U secondRecipe) {
+    public <U extends IRecipe<?>> boolean doesConflict(final IRecipeManager manager, final SmithingRecipe firstRecipe, final U secondRecipe) {
         
         if (!(secondRecipe instanceof SmithingRecipe)) {
             
@@ -66,7 +66,7 @@ public final class SmithingRecipeHandler implements IRecipeHandler<SmithingRecip
     
     private <T extends IRecipe<?>> boolean redirectNonVanilla(final IRecipeManager manager, final T second, final SmithingRecipe first) {
         
-        return CraftTweakerRegistry.getHandlerFor(second).isThereConflictBetween(manager, second, first);
+        return CraftTweakerRegistry.getHandlerFor(second).doesConflict(manager, second, first);
     }
     
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/SmithingRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/SmithingRecipeHandler.java
@@ -5,7 +5,9 @@ import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.helper.IngredientHelper;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
+import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.SmithingRecipe;
 import net.minecraft.util.ResourceLocation;
@@ -23,7 +25,7 @@ public final class SmithingRecipeHandler implements IRecipeHandler<SmithingRecip
         return String.format(
                 "smithing.addRecipe(%s, %s, %s, %s);",
                 StringUtils.quoteAndEscape(recipe.getId()),
-                new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
                 IIngredient.fromIngredient(recipe.base).getCommandString(),
                 IIngredient.fromIngredient(recipe.addition).getCommandString()
         );
@@ -40,6 +42,16 @@ public final class SmithingRecipeHandler implements IRecipeHandler<SmithingRecip
         }
         
         return Optional.of(id -> new SmithingRecipe(id, base.orElseGet(() -> recipe.base), addition.orElseGet(() -> recipe.addition), recipe.getRecipeOutput()));
+    }
+    
+    @Override
+    public boolean conflictsWith(final IRecipeManager manager, final SmithingRecipe firstRecipe, final IRecipe<?> secondRecipe) {
+        
+        if (!(secondRecipe instanceof SmithingRecipe)) return false;
+        
+        final SmithingRecipe second = (SmithingRecipe) secondRecipe;
+        
+        return IngredientHelper.canConflict(firstRecipe.base, second.base) && IngredientHelper.canConflict(firstRecipe.addition, second.addition);
     }
     
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/SmithingRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/SmithingRecipeHandler.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.impl.recipes.handlers.vanilla;
 
+import com.blamejared.crafttweaker.api.CraftTweakerRegistry;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
@@ -47,11 +48,25 @@ public final class SmithingRecipeHandler implements IRecipeHandler<SmithingRecip
     @Override
     public boolean conflictsWith(final IRecipeManager manager, final SmithingRecipe firstRecipe, final IRecipe<?> secondRecipe) {
         
-        if (!(secondRecipe instanceof SmithingRecipe)) return false;
+        if (!(secondRecipe instanceof SmithingRecipe)) {
+            
+            // If it is not an instanceof the normal recipe class, it means it has been added by a mod. To ensure symmetry,
+            // we redirect to the other recipe handler. We are sure this cannot cause an infinite loop because recipe
+            // handlers are checked based on the recipe class or superclasses. If secondRecipe were to redirect here,
+            // it means that the if above would be false. If secondRecipe were not to have a recipe handler, it would
+            // get the default of "never conflicts" anyway. Last possibility is for secondRecipe to have a mod-added
+            // handler, and infinite loops are now up to them
+            return this.redirectNonVanilla(manager, secondRecipe, firstRecipe);
+        }
         
         final SmithingRecipe second = (SmithingRecipe) secondRecipe;
         
         return IngredientHelper.canConflict(firstRecipe.base, second.base) && IngredientHelper.canConflict(firstRecipe.addition, second.addition);
+    }
+    
+    private <T extends IRecipe<?>> boolean redirectNonVanilla(final IRecipeManager manager, final T second, final SmithingRecipe first) {
+        
+        return CraftTweakerRegistry.getHandlerFor(second).conflictsWith(manager, second, first);
     }
     
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/SmithingRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/SmithingRecipeHandler.java
@@ -46,7 +46,7 @@ public final class SmithingRecipeHandler implements IRecipeHandler<SmithingRecip
     }
     
     @Override
-    public boolean conflictsWith(final IRecipeManager manager, final SmithingRecipe firstRecipe, final IRecipe<?> secondRecipe) {
+    public <U extends IRecipe<?>> boolean isThereConflictBetween(final IRecipeManager manager, final SmithingRecipe firstRecipe, final U secondRecipe) {
         
         if (!(secondRecipe instanceof SmithingRecipe)) {
             
@@ -66,7 +66,7 @@ public final class SmithingRecipeHandler implements IRecipeHandler<SmithingRecip
     
     private <T extends IRecipe<?>> boolean redirectNonVanilla(final IRecipeManager manager, final T second, final SmithingRecipe first) {
         
-        return CraftTweakerRegistry.getHandlerFor(second).conflictsWith(manager, second, first);
+        return CraftTweakerRegistry.getHandlerFor(second).isThereConflictBetween(manager, second, first);
     }
     
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/StoneCutterRecipeHandler.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/handlers/vanilla/StoneCutterRecipeHandler.java
@@ -5,7 +5,7 @@ import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.api.recipes.IRecipeHandler;
 import com.blamejared.crafttweaker.api.recipes.IReplacementRule;
 import com.blamejared.crafttweaker.api.util.StringUtils;
-import com.blamejared.crafttweaker.impl.item.MCItemStackMutable;
+import com.blamejared.crafttweaker.impl.helper.ItemStackHelper;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.StonecuttingRecipe;
 import net.minecraft.util.ResourceLocation;
@@ -23,7 +23,7 @@ public final class StoneCutterRecipeHandler implements IRecipeHandler<Stonecutti
         return String.format(
                 "stoneCutter.addRecipe(%s, %s, %s);",
                 StringUtils.quoteAndEscape(recipe.getId()),
-                new MCItemStackMutable(recipe.getRecipeOutput()).getCommandString(),
+                ItemStackHelper.getCommandString(recipe.getRecipeOutput()),
                 IIngredient.fromIngredient(recipe.getIngredients().get(0)).getCommandString()
         );
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/helper/CraftingTableRecipeConflictChecker.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/helper/CraftingTableRecipeConflictChecker.java
@@ -31,7 +31,7 @@ public final class CraftingTableRecipeConflictChecker {
     private static <T extends IRecipe<?>> boolean redirect(final IRecipeManager manager, final T second, final IRecipe<?> first) {
         
         // We need another lookup because of the wildcard capture
-        return CraftTweakerRegistry.getHandlerFor(second).isThereConflictBetween(manager, second, first);
+        return CraftTweakerRegistry.getHandlerFor(second).doesConflict(manager, second, first);
     }
     
     private static boolean checkConflictsMaybeDifferent(final IRecipe<?> first, final IRecipe<?> second) {

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/helper/CraftingTableRecipeConflictChecker.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/helper/CraftingTableRecipeConflictChecker.java
@@ -31,7 +31,7 @@ public final class CraftingTableRecipeConflictChecker {
     private static <T extends IRecipe<?>> boolean redirect(final IRecipeManager manager, final T second, final IRecipe<?> first) {
         
         // We need another lookup because of the wildcard capture
-        return CraftTweakerRegistry.getHandlerFor(second).conflictsWith(manager, second, first);
+        return CraftTweakerRegistry.getHandlerFor(second).isThereConflictBetween(manager, second, first);
     }
     
     private static boolean checkConflictsMaybeDifferent(final IRecipe<?> first, final IRecipe<?> second) {

--- a/src/main/java/com/blamejared/crafttweaker/impl/recipes/helper/CraftingTableRecipeConflictChecker.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/recipes/helper/CraftingTableRecipeConflictChecker.java
@@ -1,0 +1,111 @@
+package com.blamejared.crafttweaker.impl.recipes.helper;
+
+import com.blamejared.crafttweaker.api.CraftTweakerRegistry;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.helper.IngredientHelper;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.crafting.IShapedRecipe;
+
+import java.util.BitSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class CraftingTableRecipeConflictChecker {
+    
+    public static boolean checkConflicts(final IRecipeManager manager, final IRecipe<?> first, final IRecipe<?> second) {
+        
+        // Dynamic recipes cannot conflict by definition
+        if (first.isDynamic() || second.isDynamic()) return false;
+    
+        // (Shaped, Shapeless) must always be preferred to (Shapeless, Shaped) in this checker.
+        if (!(first instanceof IShapedRecipe<?>) && second instanceof IShapedRecipe<?>) {
+            
+            return redirect(manager, second, first);
+        }
+        
+        return checkConflictsMaybeDifferent(first, second);
+    }
+
+    private static <T extends IRecipe<?>> boolean redirect(final IRecipeManager manager, final T second, final IRecipe<?> first) {
+        
+        // We need another lookup because of the wildcard capture
+        return CraftTweakerRegistry.getHandlerFor(second).conflictsWith(manager, second, first);
+    }
+    
+    private static boolean checkConflictsMaybeDifferent(final IRecipe<?> first, final IRecipe<?> second) {
+        
+        if (first instanceof IShapedRecipe<?>) {
+            
+            if (second instanceof IShapedRecipe<?>) {
+                
+                return doShapedShapedConflict((IShapedRecipe<?>) first, (IShapedRecipe<?>) second);
+            }
+            
+            return doShapedShapelessConflict((IShapedRecipe<?>) first, second);
+        }
+        
+        return doShapelessShapelessConflict(first, second);
+    }
+    
+    private static boolean doShapedShapedConflict(final IShapedRecipe<?> first, final IShapedRecipe<?> second) {
+    
+        if (first.getRecipeHeight() != second.getRecipeHeight()) return false;
+        if (first.getRecipeWidth() != second.getRecipeWidth()) return false;
+    
+        final NonNullList<Ingredient> firstIngredients = first.getIngredients();
+        final NonNullList<Ingredient> secondIngredients = second.getIngredients();
+    
+        for (int i = 0; i < firstIngredients.size(); ++i) {
+            
+            final Ingredient firstIngredient = firstIngredients.get(i);
+            final Ingredient secondIngredient = secondIngredients.get(i);
+            
+            if (!IngredientHelper.canConflict(firstIngredient, secondIngredient)) return false;
+        }
+        
+        return true;
+    }
+    
+    private static boolean doShapedShapelessConflict(final IShapedRecipe<?> first, final IRecipe<?> second) {
+        
+        return doShapelessShapelessConflict(first.getIngredients().stream().filter(it -> it != Ingredient.EMPTY).collect(Collectors.toList()), second.getIngredients());
+    }
+    
+    private static boolean doShapelessShapelessConflict(final IRecipe<?> first, final IRecipe<?> second) {
+    
+        return doShapelessShapelessConflict(first.getIngredients(), second.getIngredients());
+    }
+    
+    private static boolean doShapelessShapelessConflict(final List<Ingredient> first, final List<Ingredient> second) {
+        
+        if (first.size() != second.size()) return false;
+    
+        return craftShapelessRecipeVirtually(first, second);
+    }
+    
+    private static boolean craftShapelessRecipeVirtually(final List<Ingredient> first, final List<Ingredient> second) {
+        
+        final BitSet visitData = new BitSet(second.size());
+    
+        for (final Ingredient target : first) {
+            
+            for(int j = 0; j < second.size(); ++j) {
+                
+                if(visitData.get(j)) continue;
+            
+                final Ingredient attempt = second.get(j);
+            
+                if(IngredientHelper.canConflict(target, attempt)) {
+                
+                    visitData.set(j);
+                    break;
+                }
+            }
+        }
+        
+        // Since all ingredients must have been used, visitData must have been set fully to 1
+        return visitData.nextClearBit(0) == second.size();
+    }
+}


### PR DESCRIPTION
This PR adds back the 1.12.2 functionality of `/ct conflicts`, expanded to take all recipe types into account.

The task of checking for conflicts between recipes of various types is deferred to `IRecipeHandler`s. This allows specialization of checking for specific recipe classes.
Backwards compatibility is kept by having a default implementation which simply reports that two recipes do not conflict for every call.

The conflict checking is also running on a separate thread on a sequential stream as benchmark results on a variety of packs and systems indicates that a single-thread is still preferable for performance.
Nevertheless, I'd suggest waiting some more in case additional results indicate the opposite trend.

As a bonus, `/ct conflicts` functionality has been expanded, allowing to specify a target recipe type or output, limiting thus the conflict checking to a subset of data.

