### PR TITLE
add LootTableIdRegexConditionTypeBuilder

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/impl/loot/conditions/vanilla/LootTableIdRegexConditionTypeBuilder.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/loot/conditions/vanilla/LootTableIdRegexConditionTypeBuilder.java
@@ -7,6 +7,8 @@ import com.blamejared.crafttweaker.impl_native.loot.ExpandLootContext;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
 import org.openzen.zencode.java.ZenCodeType;
 
+import java.util.regex.Pattern;
+
 /**
  * Builder for a 'LootTableIdRegex' loot condition.
  *
@@ -22,7 +24,7 @@ import org.openzen.zencode.java.ZenCodeType;
 @ZenCodeType.Name("crafttweaker.api.loot.conditions.vanilla.LootTableIdRegex")
 @Document("vanilla/api/loot/conditions/vanilla/LootTableIdRegex")
 public final class LootTableIdRegexConditionTypeBuilder implements ILootConditionTypeBuilder {
-    private String regex;
+    private Pattern regex;
 
     LootTableIdRegexConditionTypeBuilder() {}
 
@@ -37,7 +39,7 @@ public final class LootTableIdRegexConditionTypeBuilder implements ILootConditio
      */
     @ZenCodeType.Method
     public LootTableIdRegexConditionTypeBuilder withRegex(String regex) {
-        this.regex = regex;
+        this.regex = Pattern.compile(regex);
         return this;
     }
 
@@ -46,6 +48,6 @@ public final class LootTableIdRegexConditionTypeBuilder implements ILootConditio
         if(this.regex == null) {
             throw new IllegalStateException("Unable to have a 'LootTableIdRegex' condition without a regex");
         }
-        return context -> ExpandLootContext.getLootTableId(context).toString().matches(regex);
+        return context -> regex.matcher(ExpandLootContext.getLootTableId(context).toString()).matches();
     }
 }

--- a/src/main/java/com/blamejared/crafttweaker/impl/loot/conditions/vanilla/LootTableIdRegexConditionTypeBuilder.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/loot/conditions/vanilla/LootTableIdRegexConditionTypeBuilder.java
@@ -1,0 +1,51 @@
+package com.blamejared.crafttweaker.impl.loot.conditions.vanilla;
+
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.loot.conditions.ILootCondition;
+import com.blamejared.crafttweaker.impl.loot.conditions.ILootConditionTypeBuilder;
+import com.blamejared.crafttweaker.impl_native.loot.ExpandLootContext;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import org.openzen.zencode.java.ZenCodeType;
+
+/**
+ * Builder for a 'LootTableIdRegex' loot condition.
+ *
+ * This condition will pass if and only if the ID of the loot table currently being queried matches the target regex.
+ *
+ * While this condition is provided merely as a convenience, it is suggested not to rely on this condition only. Due to
+ * backwards compatibility, some loot tables may in fact lack an ID or have overlapping ones. Other conditions should be
+ * used instead.
+ *
+ * The 'LootTableIdRegex' condition requires a regex to be built.
+ */
+@ZenRegister
+@ZenCodeType.Name("crafttweaker.api.loot.conditions.vanilla.LootTableIdRegex")
+@Document("vanilla/api/loot/conditions/vanilla/LootTableIdRegex")
+public final class LootTableIdRegexConditionTypeBuilder implements ILootConditionTypeBuilder {
+    private String regex;
+
+    LootTableIdRegexConditionTypeBuilder() {}
+
+    /**
+     * Sets the regex of the loot table that should be targeted.
+     *
+     * This parameter is <strong>required</strong>.
+     *
+     * @param regex The regex of the loot table to match.
+     *
+     * @return This builder for chaining.
+     */
+    @ZenCodeType.Method
+    public LootTableIdRegexConditionTypeBuilder withRegex(String regex) {
+        this.regex = regex;
+        return this;
+    }
+
+    @Override
+    public ILootCondition finish() {
+        if(this.regex == null) {
+            throw new IllegalStateException("Unable to have a 'LootTableIdRegex' condition without a regex");
+        }
+        return context -> ExpandLootContext.getLootTableId(context).toString().matches(regex);
+    }
+}


### PR DESCRIPTION
This PR adds LootTableIdRegexConditionTypeBuilder. The builder uses a regex to match multiple loot tables.

For instance:

```zenscript
loot.modifiers.register(
    "just_a_name",
    LootConditionBuilder.createForSingle<LootTableIdRegex>(condition => {
        condition.withRegex("minecraft:chests/.*");
    }),
    CommonLootModifiers.remove(<item:minecraft:iron_ingot>); 
);
```

This would match all loot tables of vanilla resource chests.