### PR TITLE
fix incomplete meta wildcard matching

### DIFF
--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
@@ -375,7 +375,7 @@ public class MCItemStack implements IItemStack {
         if(stack.hasTagCompound() && matchTagExact) {
             return matchesExact(item);
         }
-        return !internal.isEmpty() && !stack.isEmpty() && internal.getItem() == stack.getItem() && (wildcardSize || internal.getCount() >= stack.getCount()) && (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE || stack.getItemDamage() == internal.getItemDamage() || (!stack.getHasSubtypes() && !stack.getItem().isDamageable()));
+        return !internal.isEmpty() && !stack.isEmpty() && internal.getItem() == stack.getItem() && (wildcardSize || internal.getCount() >= stack.getCount()) && (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE || internal.getItemDamage() == OreDictionary.WILDCARD_VALUE || stack.getItemDamage() == internal.getItemDamage() || (!stack.getHasSubtypes() && !stack.getItem().isDamageable()));
     }
     
     @Override
@@ -391,7 +391,7 @@ public class MCItemStack implements IItemStack {
             return false;
         }
         
-        boolean itemMatches = stack.getItem() == internal.getItem() && (internal.getMetadata() == OreDictionary.WILDCARD_VALUE || stack.getMetadata() == internal.getMetadata());
+        boolean itemMatches = stack.getItem() == internal.getItem() && (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE || internal.getItemDamage() == OreDictionary.WILDCARD_VALUE || stack.getMetadata() == internal.getMetadata());
         
         if(itemMatches) {
     


### PR DESCRIPTION
Fix only checking meta wildcard on one item rather than both.
```zenscript
val wildcard = <minecraft:iron_shovel:*>.withTag({RepairCost: 0, display: {Name: "Test Shovel"}});
val toCheck = <minecraft:iron_shovel:144>.withTag({RepairCost: 0, display: {Name: "Test Shovel"}});

wildcard.matches(toCheck); // returns false, but it should be true
```