### PR TITLE
Fix Typed Expansions not working

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/api/zencode/impl/native_types/CrTJavaNativeConverter.java
+++ b/src/main/java/com/blamejared/crafttweaker/api/zencode/impl/native_types/CrTJavaNativeConverter.java
@@ -2,6 +2,7 @@ package com.blamejared.crafttweaker.api.zencode.impl.native_types;
 
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
+import com.blamejared.crafttweaker_annotations.annotations.TypedExpansion;
 import org.openzen.zencode.java.module.JavaNativeTypeConversionContext;
 import org.openzen.zencode.java.module.converters.JavaNativeClassConverter;
 import org.openzen.zencode.java.module.converters.JavaNativeConverter;
@@ -23,7 +24,7 @@ class CrTJavaNativeConverter extends JavaNativeConverter {
     public HighLevelDefinition addClass(Class<?> cls) {
         
         try {
-            if(cls.isAnnotationPresent(NativeTypeRegistration.class)) {
+            if(cls.isAnnotationPresent(NativeTypeRegistration.class) || cls.isAnnotationPresent(TypedExpansion.class)) {
                 return expansionConverter.convertExpansion(cls);
             }
             


### PR DESCRIPTION
This fixes TypedExpansions being registered via `JavaNativeConverter.classConverter#convertClass` instead of `JavaNativeConverter.expansionConverter#convertExpansion`. I am not quite positive if this is the correct way to fix it but I believe it is at least close. One issue this way does have (that also exists for NativeTypeRegistration expansions) is that because of where the check is injected, it means that neither `typeConversionContext.definitionByClass` nor the class being public is checked. One solution could be to add aprotected method in JavaNativeConverter for `isConvertableExpansion` that then is overridden to add the other two types and lets it get called after the checks but I went with just following how it is done for `NativeTypeRegistration` for now.