### PR TITLE
Avoid unnecessary copies with CrTMC#getIItemStack

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/CraftTweakerAPI.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/CraftTweakerAPI.java
@@ -255,7 +255,6 @@ public class CraftTweakerAPI {
      *
      * @param annotatedClass class that is annotated
      */
-    @SuppressWarnings("deprecation") // Java 11+ for RedHat
     public static void registerClass(Class<?> annotatedClass) {
         boolean registered = false;
         for(Annotation annotation : annotatedClass.getAnnotations()) {

--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/event/PlayerWakeUpEvent.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/event/PlayerWakeUpEvent.java
@@ -3,7 +3,6 @@ package crafttweaker.api.event;
 import crafttweaker.annotations.ZenRegister;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenGetter;
-import stanhebben.zenscript.annotations.ZenSetter;
 
 /**
  * @author Stan

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/api/minecraft/CraftTweakerMC.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/api/minecraft/CraftTweakerMC.java
@@ -45,6 +45,7 @@ import crafttweaker.mc1120.entity.attribute.MCEntityAttributeModifier;
 import crafttweaker.mc1120.entity.expand.ExpandEntityEquipmentSlot;
 import crafttweaker.mc1120.game.MCTeam;
 import crafttweaker.mc1120.item.MCItemStack;
+import crafttweaker.mc1120.item.MCMutableItemStack;
 import crafttweaker.mc1120.item.VanillaIngredient;
 import crafttweaker.mc1120.liquid.MCLiquidDefinition;
 import crafttweaker.mc1120.liquid.MCLiquidStack;
@@ -222,10 +223,60 @@ public class CraftTweakerMC {
      * @return crafttweaker stack
      */
     public static IItemStack getIItemStackWildcardSize(ItemStack item) {
-        if(item.isEmpty())
+        if(item == null || item.isEmpty())
             return null;
         
         return new MCItemStack(item, true);
+    }
+
+    /**
+     * Returns the CraftTweaker mutable item stack for this item.
+     *
+     * @param item minecraft item stack
+     *
+     * @return crafttweaker mutable item stack
+     */
+    public static IItemStack getIItemStackMutable(ItemStack item) {
+        if (item == null || item.isEmpty())
+            return null;
+
+        return new MCMutableItemStack(item);
+    }
+
+    /**
+     * Constructs a mutable item stack with wildcard size.
+     *
+     * @param item minecraft item stack
+     *
+     * @return crafttweaker mutable item stack
+     */
+    public static IItemStack getIItemStackMutableWildcardSize(ItemStack item) {
+        if (item == null || item.isEmpty())
+            return null;
+
+        return new MCMutableItemStack(item, true);
+    }
+
+    /**
+     * Constructs an item stack for matching. Less performance-heavy than normal getIItemStack.
+     * 
+     * @param item minecraft item stack
+     * 
+     * @return crafttweaker item stack for matching
+     */
+    public static IItemStack getIItemStackForMatching(ItemStack item) {
+        return getIItemStackForMatching(item, false);
+    }
+
+    /**
+     * Constructs an item stack for matching with wildcard size. Less performance-heavy than normal getIItemStack.
+     * 
+     * @param item minecraft item stack
+     * 
+     * @return crafttweaker item stack for matching
+     */
+    public static IItemStack getIItemStackForMatching(ItemStack item, boolean wildcardSize) {
+        return wildcardSize ? getIItemStackMutableWildcardSize(item) : getIItemStackMutable(item);
     }
     
     /**
@@ -239,6 +290,7 @@ public class CraftTweakerMC {
     public static IItemStack getIItemStackWildcardSize(Item item, int meta) {
         if(item == null)
             return null;
+        
         return new MCItemStack(new ItemStack(item, 1, meta), true);
     }
     

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/actions/ActionFurnaceRemoveRecipe.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/actions/ActionFurnaceRemoveRecipe.java
@@ -6,9 +6,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
-import static crafttweaker.api.minecraft.CraftTweakerMC.getIItemStack;
+import static crafttweaker.api.minecraft.CraftTweakerMC.getIItemStackForMatching;
 
 public class ActionFurnaceRemoveRecipe implements IActionFurnaceRemoval {
     
@@ -26,20 +25,20 @@ public class ActionFurnaceRemoveRecipe implements IActionFurnaceRemoval {
         Map<ItemStack, ItemStack> smeltingList = FurnaceRecipes.instance().getSmeltingList();
         if(input == null) {
             for(Map.Entry<ItemStack, ItemStack> entry : smeltingList.entrySet()) {
-                if(output.matches(getIItemStack(entry.getValue()))) {
+                if(output.matches(getIItemStackForMatching(entry.getValue()))) {
                     smeltingMap.put(entry.getKey(), entry.getValue());
                 }
             }
         } else {
             for(Map.Entry<ItemStack, ItemStack> entry : smeltingList.entrySet()) {
-                if(output.matches(getIItemStack(entry.getValue())) && input.matches(getIItemStack(entry.getKey()))) {
+                if(output.matches(getIItemStackForMatching(entry.getValue())) && input.matches(getIItemStackForMatching(entry.getKey()))) {
                     smeltingMap.put(entry.getKey(), entry.getValue());
                 }
             }
         }
         for(Map.Entry<ItemStack, ItemStack> entry : smeltingMap.entrySet()) {
             FurnaceRecipes.instance().getSmeltingList().remove(entry.getKey(), entry.getValue());
-            FurnaceRecipes.instance().experienceList.keySet().removeIf(itemStack -> output.matches(getIItemStack(itemStack)));
+            FurnaceRecipes.instance().experienceList.keySet().removeIf(itemStack -> output.matches(getIItemStackForMatching(itemStack)));
         }
         CraftTweakerAPI.logInfo(smeltingMap.size() + " recipes removed for: " + output);
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/actions/ActionRemoveSeed.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/actions/ActionRemoveSeed.java
@@ -26,7 +26,7 @@ public class ActionRemoveSeed implements IAction {
             
             for(Object entry : SEEDS) {
                 ItemStack itemStack = CraftTweakerHacks.getSeedEntrySeed(entry);
-                if(pattern.matches(CraftTweakerMC.getIItemStack(itemStack))) {
+                if(pattern.matches(CraftTweakerMC.getIItemStackForMatching(itemStack))) {
                     removed.add(entry);
                 }
             }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brewing/MultiBrewingRecipe.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brewing/MultiBrewingRecipe.java
@@ -29,12 +29,12 @@ public class MultiBrewingRecipe implements IBrewingRecipe {
 
 	@Override
 	public boolean isIngredient(ItemStack tester) {
-		return ingredient.matches(CraftTweakerMC.getIItemStack(tester)); 
+		return ingredient.matches(CraftTweakerMC.getIItemStackForMatching(tester)); 
 	}
 
 	@Override
 	public boolean isInput(ItemStack tester) {
-		return input.matches(CraftTweakerMC.getIItemStack(tester));
+		return input.matches(CraftTweakerMC.getIItemStackForMatching(tester));
 	}
 	
 	public ItemStack getOutput() {

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brewing/VanillaBrewingPlus.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/brewing/VanillaBrewingPlus.java
@@ -21,8 +21,8 @@ public final class VanillaBrewingPlus extends VanillaBrewingRecipe {
 
     @Override
     public ItemStack getOutput(ItemStack input, ItemStack ingredient) {
-        IItemStack _input = CraftTweakerMC.getIItemStack(input);
-        IItemStack _ingredient = CraftTweakerMC.getIItemStack(ingredient);
+        IItemStack _input = CraftTweakerMC.getIItemStackForMatching(input);
+        IItemStack _ingredient = CraftTweakerMC.getIItemStackForMatching(ingredient);
 
         if (removedRecipes.stream().anyMatch(t -> t.getFirst().matches(_input) && t.getSecond().matches(_ingredient))) {
             return ItemStack.EMPTY;
@@ -33,7 +33,7 @@ public final class VanillaBrewingPlus extends VanillaBrewingRecipe {
 
     @Override
     public boolean isIngredient(@Nonnull ItemStack stack) {
-        IItemStack _ingredient = CraftTweakerMC.getIItemStack(stack);
+        IItemStack _ingredient = CraftTweakerMC.getIItemStackForMatching(stack);
 
         return super.isIngredient(stack) && removedRecipes.stream().noneMatch(t -> t.getFirst() == IngredientAny.INSTANCE && t.getSecond().matches(_ingredient));
     }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/CommonEventHandler.java
@@ -234,7 +234,7 @@ public class CommonEventHandler {
         List<IItemStack> ingredients = MCOreDictEntry.REMOVED_CONTENTS.get(ev.getName());
         if (ingredients != null)
             for (IItemStack ingredient : ingredients)
-                if (ingredient.matches(CraftTweakerMC.getIItemStack(ev.getOre())))
+                if (ingredient.matches(CraftTweakerMC.getIItemStackForMatching(ev.getOre())))
                     OreDictionary.getOres(ev.getName()).remove(ev.getOre());
     }
     

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCPlayerWakeUpEvent.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/events/handling/MCPlayerWakeUpEvent.java
@@ -3,8 +3,6 @@ package crafttweaker.mc1120.events.handling;
 import crafttweaker.api.event.PlayerWakeUpEvent;
 import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.api.player.IPlayer;
-import crafttweaker.api.world.IBlockPos;
-import net.minecraft.entity.player.EntityPlayer;
 
 public class MCPlayerWakeUpEvent implements PlayerWakeUpEvent {
 

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCItemStack.java
@@ -99,7 +99,7 @@ public class MCItemStack implements IItemStack {
         this.tag = tag;
     }
     
-    private MCItemStack(ItemStack itemStack, IData tag, boolean wildcardSize) {
+    protected MCItemStack(ItemStack itemStack, IData tag, boolean wildcardSize) {
         if(itemStack.isEmpty())
             throw new IllegalArgumentException("stack cannot be null");
         stack = itemStack;
@@ -111,7 +111,7 @@ public class MCItemStack implements IItemStack {
     
     /**
      * This is a constructor which creates a itemstack that doesn't copy the internal stack
-     * Only use this is you are sure it will never be changed
+     * Only use this if you are sure it will never be changed
      *
      * @param unused to prevent constructor conflicts, has no purpose
      */

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCMutableItemStack.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/MCMutableItemStack.java
@@ -26,6 +26,10 @@ public class MCMutableItemStack extends MCItemStack implements IMutableItemStack
         super(itemStack, NBTConverter.from(itemStack.getTagCompound(), false));
     }
 
+    public MCMutableItemStack(ItemStack itemStack, boolean wildcardSize) {
+        super(itemStack, NBTConverter.from(itemStack.getTagCompound(), false), wildcardSize);
+    }
+
     @Override
     public void shrink(int quality) {
         origin.shrink(quality);

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/VanillaIngredient.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/item/VanillaIngredient.java
@@ -31,7 +31,7 @@ public class VanillaIngredient extends Ingredient {
     
     @Override
     public boolean apply(@Nullable ItemStack itemStack) {
-        return ingredient.matches(CraftTweakerMC.getIItemStack(itemStack));
+        return ingredient.matches(CraftTweakerMC.getIItemStackForMatching(itemStack));
     }
     
     @Override

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/oredict/MCOreDictEntry.java
@@ -136,7 +136,7 @@ public class MCOreDictEntry implements IOreDictEntry {
             REMOVED_CONTENTS.get(id).add(item);
             ItemStack result = ItemStack.EMPTY;
             for(ItemStack itemStack : OreDictionary.getOres(id)) {
-                if(item.matches(getIItemStackWildcardSize(itemStack))) {
+                if(item.matches(getIItemStackForMatching(itemStack, true))) {
                     result = itemStack;
                     break;
                 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeManager.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeManager.java
@@ -5,7 +5,6 @@ import crafttweaker.IAction;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.item.IngredientOr;
-import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.api.recipes.*;
 import crafttweaker.mc1120.CraftTweaker;
 import crafttweaker.mc1120.item.MCItemStack;
@@ -31,6 +30,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static crafttweaker.api.minecraft.CraftTweakerMC.getIItemStackForMatching;
 import static crafttweaker.api.minecraft.CraftTweakerMC.getIItemStack;
 import static crafttweaker.api.minecraft.CraftTweakerMC.getItemStack;
 import static crafttweaker.api.minecraft.CraftTweakerMC.getOreDict;
@@ -54,7 +54,8 @@ public final class MCRecipeManager implements IRecipeManager {
     }
     
     private static boolean matchesItem(ItemStack input, IIngredient ingredient) {
-        return ingredient == null ? input.isEmpty() : !input.isEmpty() && ingredient.matches(getIItemStack(input));
+        return ingredient == null ? input.isEmpty() : 
+                !input.isEmpty() && ingredient.matches(getIItemStackForMatching(input));
     }
     
     private static boolean matches(Object input, IIngredient ingredient) {
@@ -124,7 +125,7 @@ public final class MCRecipeManager implements IRecipeManager {
         for(Map.Entry<ResourceLocation, IRecipe> ent : recipes) {
             ItemStack stack = ent.getValue().getRecipeOutput();
             if(!stack.isEmpty()) {
-                if(ingredient.matches(CraftTweakerMC.getIItemStack(stack))) {
+                if(ingredient.matches(getIItemStackForMatching(stack))) {
                     if(ent.getValue() instanceof MCRecipeBase) {
                         results.add((MCRecipeBase) ent.getValue());
                     } else
@@ -341,7 +342,7 @@ public final class MCRecipeManager implements IRecipeManager {
             for(Map.Entry<ResourceLocation, IRecipe> recipeEntry : recipes) {
                 final IRecipe recipe = recipeEntry.getValue();
                 final ItemStack output = recipe.getRecipeOutput();
-                if(output.isEmpty() || !this.output.matches(MCItemStack.createNonCopy(output))) {
+                if(output.isEmpty() || !this.output.matches(getIItemStackForMatching(output))) {
                     continue;
                 }
                 
@@ -367,7 +368,7 @@ public final class MCRecipeManager implements IRecipeManager {
                                 } else {
                                     input = ing.getMatchingStacks()[0];
                                 }
-                                if(!matches(input, ingredient)) {
+                                if(!matchesItem(input, ingredient)) {
                                     continue outer;
                                 }
                             }
@@ -414,7 +415,7 @@ public final class MCRecipeManager implements IRecipeManager {
             outer:
             for(Map.Entry<ResourceLocation, IRecipe> entry : recipes) {
                 IRecipe recipe = entry.getValue();
-                if(entry.getValue().getRecipeOutput().isEmpty() || !output.matches(MCItemStack.createNonCopy(entry.getValue().getRecipeOutput()))) {
+                if(entry.getValue().getRecipeOutput().isEmpty() || !output.matches(getIItemStackForMatching(entry.getValue().getRecipeOutput()))) {
                     continue;
                 }
                 if(recipe instanceof IShapedRecipe) {
@@ -499,7 +500,7 @@ public final class MCRecipeManager implements IRecipeManager {
             
             for(Map.Entry<ResourceLocation, IRecipe> recipe : recipes) {
                 ItemStack recipeOutput = recipe.getValue().getRecipeOutput();
-                IItemStack stack = getIItemStack(recipeOutput);
+                IItemStack stack = getIItemStackForMatching(recipeOutput);
                 if(stack != null && matches(stack)) {
                     toRemove.add(recipe.getKey());
                 }
@@ -543,7 +544,7 @@ public final class MCRecipeManager implements IRecipeManager {
             for(Map.Entry<ResourceLocation, IRecipe> recipe : recipes) {
                 if(recipe.getKey().toString().equals(recipeName)) {
                     if(filter != null) {
-                        if(filter.matches(getIItemStack(recipe.getValue().getRecipeOutput())))
+                        if(filter.matches(getIItemStackForMatching(recipe.getValue().getRecipeOutput())))
                             toRemove.add(recipe.getKey());
                     } else {
                         toRemove.add(recipe.getKey());
@@ -613,7 +614,7 @@ public final class MCRecipeManager implements IRecipeManager {
                 Matcher m = p.matcher(resourceLocation.toString());
                 if(m.matches()) {
                     if(filter != null) {
-                        if(filter.matches(getIItemStack(recipe.getValue().getRecipeOutput())))
+                        if(filter.matches(getIItemStackForMatching(recipe.getValue().getRecipeOutput())))
                             toRemove.add(recipe.getKey());
                     } else {
                         toRemove.add(resourceLocation);

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeShaped.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeShaped.java
@@ -300,7 +300,7 @@ public class MCRecipeShaped extends MCRecipeBase implements IShapedRecipe {
                                 continue;
                             else
                                 return offsetInvalid;
-                        if(itemStack.isEmpty() || !ingredients[row][column].matches(CraftTweakerMC.getIItemStack(itemStack)))
+                        if(itemStack.isEmpty() || !ingredients[row][column].matches(CraftTweakerMC.getIItemStackForMatching(itemStack)))
                             continue outer;
                         visited[(column + columnOffset) + (row + rowOffset) * inv.getWidth()] = true;
 

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeShapeless.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/recipes/MCRecipeShapeless.java
@@ -47,7 +47,7 @@ public class MCRecipeShapeless extends MCRecipeBase {
                 ItemStack stackInSlot = inv.getStackInSlot(slot);
                 if(visited[slot] || stackInSlot.isEmpty())
                     continue;
-                if(ingredient.matches(CraftTweakerMC.getIItemStack(stackInSlot))) {
+                if(ingredient.matches(CraftTweakerMC.getIItemStackForMatching(stackInSlot))) {
                     //make sure no slot is matched twice
                     visited[slot] = true;
                     continue outer;


### PR DESCRIPTION
Replaces instances of `iingredient.matches(getIItemStack(istack))` with `iingredient.matches(getIItemStackForMatching(istack))`.

In a large pack with hundreds of mods, calling `ItemStack.copy()` is a very expensive operation. Due to the mutable itemstack rework, calling `CraftTweakerMC.getIItemStack` always invokes the MCItemStack constructor, which results in a new copy being created. At about 13ms per invocation, in a modpack with over 300 mods, this amounts to about 80,000 ms (and 6,000 invocations). However, many calls for getIItemStack don't even most of the functions of the IItemStack, as they usually just compare it directly to an IIngredient. This means a lot of these calls to `ItemStack.copy()` are wholly unnecessary.

To remedy this problem even just slightly, this PR avoids those `copy()` calls in highly frequented methods to save much of that 80 seconds.