### PR TITLE
Fix ingredients being cached too early. Close #1510

### DIFF
--- a/Common/src/main/java/com/blamejared/crafttweaker/api/ingredient/IngredientCacheBuster.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/ingredient/IngredientCacheBuster.java
@@ -1,6 +1,7 @@
 package com.blamejared.crafttweaker.api.ingredient;
 
 import com.blamejared.crafttweaker.mixin.common.access.item.AccessIngredient;
+import com.blamejared.crafttweaker.platform.Services;
 import net.minecraft.world.item.crafting.Ingredient;
 
 import java.util.ArrayList;
@@ -28,10 +29,7 @@ public class IngredientCacheBuster {
     public static void release() {
         
         claimed = false;
-        ingredients.forEach(ingredient -> {
-            ((AccessIngredient) (Object) ingredient).crafttweaker$setItemStacks(null);
-        });
-        ingredients.clear();
+        Services.PLATFORM.invalidateIngredients(ingredients);
     }
     
     /**

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/ingredient/IngredientCacheBuster.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/ingredient/IngredientCacheBuster.java
@@ -1,0 +1,57 @@
+package com.blamejared.crafttweaker.api.ingredient;
+
+import com.blamejared.crafttweaker.mixin.common.access.item.AccessIngredient;
+import net.minecraft.world.item.crafting.Ingredient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Used to bust the {@link Ingredient}#itemStacks cache when the {@link Ingredient} was resolved during a Server reload (When an instance of {@link net.minecraft.tags.TagManager} is available.
+ */
+public class IngredientCacheBuster {
+    
+    private static boolean claimed;
+    private static final List<Ingredient> ingredients = new ArrayList<>();
+    
+    /**
+     * Starts caching ingredients that are dissolved.
+     */
+    public static void claim() {
+        
+        claimed = true;
+    }
+    
+    /**
+     * Stops caching dissolved {@link Ingredient}s and invalidates the {@link Ingredient}s that were dissolved while claimed.
+     */
+    public static void release() {
+        
+        claimed = false;
+        ingredients.forEach(ingredient -> {
+            ((AccessIngredient) (Object) ingredient).crafttweaker$setItemStacks(null);
+        });
+        ingredients.clear();
+    }
+    
+    /**
+     * Returns true if the cache buster is running.
+     *
+     * @return true if the cache buster is running, false otherwise.
+     */
+    public static boolean claimed() {
+        
+        return claimed;
+    }
+    
+    /**
+     * Stores an {@link Ingredient} being dissolved to be invalidated at a later point.
+     *
+     * @param ingredient The ingredient to invalidate at a later point.
+     */
+    public static void store(Ingredient ingredient) {
+        
+        ingredients.add(ingredient);
+    }
+    
+}

--- a/Common/src/main/java/com/blamejared/crafttweaker/impl/script/ScriptReloadListener.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/impl/script/ScriptReloadListener.java
@@ -4,11 +4,13 @@ import com.blamejared.crafttweaker.CraftTweakerCommon;
 import com.blamejared.crafttweaker.CraftTweakerRegistries;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.CraftTweakerConstants;
+import com.blamejared.crafttweaker.api.ingredient.IngredientCacheBuster;
 import com.blamejared.crafttweaker.api.tag.CraftTweakerTagRegistry;
 import com.blamejared.crafttweaker.api.util.sequence.SequenceManager;
 import com.blamejared.crafttweaker.api.zencode.scriptrun.IScriptRun;
 import com.blamejared.crafttweaker.api.zencode.scriptrun.ScriptRunConfiguration;
 import com.blamejared.crafttweaker.impl.helper.FileGathererHelper;
+import com.blamejared.crafttweaker.mixin.common.access.item.AccessIngredient;
 import com.blamejared.crafttweaker.mixin.common.access.recipe.AccessRecipeManager;
 import com.blamejared.crafttweaker.mixin.common.access.tag.AccessTagManager;
 import com.blamejared.crafttweaker.platform.helper.IAccessibleServerElementsProvider;
@@ -28,14 +30,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
@@ -64,6 +59,7 @@ public class ScriptReloadListener extends SimplePreparableReloadListener<Void> {
     @Override
     protected void apply(Void object, ResourceManager resourceManager, ProfilerFiller profiler) {
     
+        IngredientCacheBuster.claim();
         SequenceManager.clearSequences();
         IAccessibleServerElementsProvider asep = CraftTweakerAPI.getAccessibleElementsProvider().server();
         asep.resources(this.resources);
@@ -92,6 +88,7 @@ public class ScriptReloadListener extends SimplePreparableReloadListener<Void> {
             
             this.displayPatreonBranding();
         }
+        IngredientCacheBuster.release();
     }
     
     private void fixRecipeManager(final RecipeManager manager) {

--- a/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/access/item/AccessIngredient.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/access/item/AccessIngredient.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.mixin.common.access.item;
 
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -15,5 +16,11 @@ public interface AccessIngredient {
     
     @Accessor("values")
     Ingredient.Value[] crafttweaker$getValues();
+    
+    @Accessor("itemStacks")
+    ItemStack[] crafttweaker$getItemStacks();
+    
+    @Accessor("itemStacks")
+    void crafttweaker$setItemStacks(ItemStack[] itemStacks);
     
 }

--- a/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/item/MixinIngredient.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/item/MixinIngredient.java
@@ -1,0 +1,21 @@
+package com.blamejared.crafttweaker.mixin.common.transform.item;
+
+import com.blamejared.crafttweaker.api.ingredient.IngredientCacheBuster;
+import net.minecraft.world.item.crafting.Ingredient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Ingredient.class)
+public class MixinIngredient {
+    
+    @Inject(method = "dissolve", at = @At("HEAD"))
+    public void crafttweaker$storeDissolve(CallbackInfo ci) {
+        
+        if(IngredientCacheBuster.claimed()) {
+            IngredientCacheBuster.store((Ingredient) (Object) this);
+        }
+    }
+    
+}

--- a/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/item/MixinIngredientTagValue.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/item/MixinIngredientTagValue.java
@@ -1,0 +1,51 @@
+package com.blamejared.crafttweaker.mixin.common.transform.item;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.ingredient.IngredientCacheBuster;
+import com.blamejared.crafttweaker.api.util.GenericUtil;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.tags.Tag;
+import net.minecraft.tags.TagKey;
+import net.minecraft.tags.TagManager;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Collection;
+import java.util.List;
+
+@Mixin(Ingredient.TagValue.class)
+public class MixinIngredientTagValue {
+    
+    @Shadow
+    @Final
+    private TagKey<Item> tag;
+    
+    @Inject(method = "getItems", at = @At("HEAD"), cancellable = true)
+    public void crafttweaker$injectTags(CallbackInfoReturnable<Collection<ItemStack>> cir) {
+        
+        if(IngredientCacheBuster.claimed()) {
+            
+            cir.setReturnValue(CraftTweakerAPI.getAccessibleElementsProvider()
+                    .server()
+                    .accessibleResources()
+                    .crafttweaker$getTagManager().getResult().stream()
+                    .filter(loadResult -> loadResult.key().equals(Registry.ITEM_REGISTRY))
+                    .map(GenericUtil::<TagManager.LoadResult<Item>>uncheck)
+                    .flatMap(loadResult -> loadResult.tags()
+                            .getOrDefault(this.tag.location(), new Tag<>(List.of()))
+                            .getValues()
+                            .stream()
+                            .map(Holder::value)
+                            .map(ItemStack::new)).toList());
+        }
+    }
+    
+}

--- a/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/item/MixinIngredientTagValue.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/item/MixinIngredientTagValue.java
@@ -19,7 +19,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Objects;
 
 @Mixin(Ingredient.TagValue.class)
 public class MixinIngredientTagValue {
@@ -39,12 +39,14 @@ public class MixinIngredientTagValue {
                     .crafttweaker$getTagManager().getResult().stream()
                     .filter(loadResult -> loadResult.key().equals(Registry.ITEM_REGISTRY))
                     .map(GenericUtil::<TagManager.LoadResult<Item>>uncheck)
-                    .flatMap(loadResult -> loadResult.tags()
-                            .getOrDefault(this.tag.location(), new Tag<>(List.of()))
-                            .getValues()
-                            .stream()
-                            .map(Holder::value)
-                            .map(ItemStack::new)).toList());
+                    .map(TagManager.LoadResult::tags)
+                    .map(map -> map.get(this.tag.location()))
+                    .filter(Objects::nonNull)
+                    .map(Tag::getValues)
+                    .flatMap(Collection::stream)
+                    .map(Holder::value)
+                    .map(ItemStack::new)
+                    .toList());
         }
     }
     

--- a/Common/src/main/java/com/blamejared/crafttweaker/platform/services/IPlatformHelper.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/platform/services/IPlatformHelper.java
@@ -6,6 +6,7 @@ import com.blamejared.crafttweaker.api.mod.Mod;
 import com.blamejared.crafttweaker.api.recipe.manager.base.IRecipeManager;
 import com.blamejared.crafttweaker.api.villager.CTTradeObject;
 import com.blamejared.crafttweaker.impl.script.ScriptRecipe;
+import com.blamejared.crafttweaker.mixin.common.access.item.AccessIngredient;
 import com.blamejared.crafttweaker.platform.helper.inventory.IInventoryWrapper;
 import com.mojang.datafixers.util.Either;
 import com.mojang.datafixers.util.Pair;
@@ -22,6 +23,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.material.Fluid;
@@ -173,6 +175,14 @@ public interface IPlatformHelper {
     default void removeFoodPropertiesEffect(FoodProperties internal, MobEffect effect) {
         
         internal.getEffects().removeIf(pair -> pair.getFirst().getEffect() == effect);
+    }
+    
+    default void invalidateIngredients(List<Ingredient> ingredients) {
+        
+        ingredients.forEach(ingredient -> {
+            ((AccessIngredient) (Object) ingredient).crafttweaker$setItemStacks(null);
+        });
+        ingredients.clear();
     }
     
 }

--- a/Common/src/main/resources/crafttweaker.mixins.json
+++ b/Common/src/main/resources/crafttweaker.mixins.json
@@ -30,6 +30,8 @@
     "common.access.villager.AccessItemsForEmeralds",
     "common.access.villager.AccessTippedArrowForItemsAndEmeralds",
     "common.access.world.biome.AccessBiome",
+    "common.transform.item.MixinIngredient",
+    "common.transform.item.MixinIngredientTagValue",
     "common.transform.world.level.MixinServerLevel"
   ],
   "client": [

--- a/Forge/src/main/java/com/blamejared/crafttweaker/platform/ForgePlatformHelper.java
+++ b/Forge/src/main/java/com/blamejared/crafttweaker/platform/ForgePlatformHelper.java
@@ -39,6 +39,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.level.material.Fluid;
@@ -340,6 +341,16 @@ public class ForgePlatformHelper implements IPlatformHelper {
         
         ((AccessFoodPropertiesForge) internal).crafttweaker$getEffects()
                 .removeIf(pair -> pair.getFirst() != null && pair.getFirst().get().getEffect() == effect);
+    }
+    
+    @Override
+    public void invalidateIngredients(List<Ingredient> ingredients) {
+        
+        Ingredient.invalidateAll();
+        for(Ingredient ingredient : ingredients) {
+            ingredient.checkInvalidation();
+        }
+        ingredients.clear();
     }
     
 }


### PR DESCRIPTION
The basics of what is going on:

1) At the start of the CRT reload, set a boolean to true
2) If an Ingredient is dissolved while that boolean is true, add it to a list
3) When `TagValue#getItems` is called while that boolean is true, query the `TagManager` directly (which has already loaded tags, but has not been saved to the registry)
4) At the end of the CRT reload, set the boolean to false, loop through the list of ingredients that was made in 2 and set `Ingredient#itemStacks` to null (as if it was never dissolved to begin with), clear the list