### PR TITLE
Implement a tag specific loader for niche tag lookups before scripts run

### DIFF
--- a/Common/src/main/java/com/blamejared/crafttweaker/api/CraftTweakerConstants.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/CraftTweakerConstants.java
@@ -14,6 +14,7 @@ public final class CraftTweakerConstants {
     public static final String ALL_LOADERS_MARKER = "*";
     public static final String INIT_LOADER_NAME = "initialize";
     public static final String DEFAULT_LOADER_NAME = "crafttweaker";
+    public static final String TAGS_LOADER_NAME = "tags";
     
     /**
      * This is not the mod version, this is specifically for the network!!

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/bracket/BracketHandlers.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/bracket/BracketHandlers.java
@@ -332,12 +332,13 @@ public class BracketHandlers {
      * @return The location
      *
      * @docParam tokens "minecraft:dirt"
+     * @deprecated Use {@link ResourceLocationBracketHandler#getResourceLocation(String)} instead.
      */
+    @Deprecated(forRemoval = true)
     @ZenCodeType.Method
-    @BracketResolver("resource")
     public static ResourceLocation getResourceLocation(String tokens) {
         
-        return new ResourceLocation(tokens);
+        return ResourceLocationBracketHandler.getResourceLocation(tokens);
     }
     
     /**

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/bracket/CommandStringDisplayable.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/bracket/CommandStringDisplayable.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.api.bracket;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
 import org.openzen.zencode.java.ZenCodeType;
@@ -9,7 +10,7 @@ import org.openzen.zencode.java.ZenCodeType;
  *
  * @docParam this null
  */
-@ZenRegister
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @ZenCodeType.Name("crafttweaker.api.bracket.CommandStringDisplayable")
 @Document("vanilla/api/bracket/CommandStringDisplayable")
 public interface CommandStringDisplayable {

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/bracket/ResourceLocationBracketHandler.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/bracket/ResourceLocationBracketHandler.java
@@ -1,0 +1,35 @@
+package com.blamejared.crafttweaker.api.bracket;
+
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
+import com.blamejared.crafttweaker.api.annotation.BracketResolver;
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import net.minecraft.resources.ResourceLocation;
+import org.openzen.zencode.java.ZenCodeType;
+
+/**
+ * Bracket handlers specifically for resource location as it is used in multiple loaders.
+ */
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
+@ZenCodeType.Name("crafttweaker.api.bracket.ResourceLocationBracketHandler")
+@Document("vanilla/api/ResourceLocationBracketHandler")
+public class ResourceLocationBracketHandler {
+    
+    /**
+     * Creates a Resource location based on the tokens.
+     * Throws an error if the tokens are not a valid location.
+     *
+     * @param tokens The resource location
+     *
+     * @return The location
+     *
+     * @docParam tokens "minecraft:dirt"
+     */
+    @ZenCodeType.Method
+    @BracketResolver("resource")
+    public static ResourceLocation getResourceLocation(String tokens) {
+        
+        return new ResourceLocation(tokens);
+    }
+    
+}

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/data/base/ICollectionData.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/data/base/ICollectionData.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.api.data.base;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker.api.data.ByteArrayData;
 import com.blamejared.crafttweaker.api.data.ByteData;
@@ -18,7 +19,7 @@ import java.util.Arrays;
  *
  * @docParam this new ListData(["Hello", "World"])
  */
-@ZenRegister
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @ZenCodeType.Name("crafttweaker.api.data.ICollectionData")
 @Document("vanilla/api/data/ICollectionData")
 public interface ICollectionData extends IData {

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/data/base/IData.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/data/base/IData.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.api.data.base;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker.api.data.BoolData;
 import com.blamejared.crafttweaker.api.data.ByteData;
@@ -22,8 +23,8 @@ import java.util.Map;
  *
  * @docParam this {Display: {lore: ["Hello", "World"]}}
  */
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @ZenCodeType.Name("crafttweaker.api.data.IData")
-@ZenRegister
 @Document("vanilla/api/data/IData")
 public interface IData {
     

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/data/base/INumberData.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/data/base/INumberData.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.api.data.base;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
 import net.minecraft.nbt.NumericTag;
@@ -10,8 +11,8 @@ import org.openzen.zencode.java.ZenCodeType;
  *
  * @docParam this 1
  */
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @Document("vanilla/api/data/INumberData")
-@ZenRegister
 @ZenCodeType.Name("crafttweaker.api.data.INumberData")
 public interface INumberData extends IData {
     

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/tag/MCTag.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/tag/MCTag.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.api.tag;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker.api.bracket.CommandStringDisplayable;
 import com.blamejared.crafttweaker.api.tag.manager.ITagManager;
@@ -20,7 +21,7 @@ import java.util.List;
 /**
  * @docParam this <tag:items:minecraft:wool>
  */
-@ZenRegister
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @Document("vanilla/api/tag/MCTag")
 @ZenCodeType.Name("crafttweaker.api.tag.MCTag")
 public interface MCTag extends CommandStringDisplayable, Comparable<MCTag> {

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/tag/manager/ITagManager.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/tag/manager/ITagManager.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.api.tag.manager;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker.api.bracket.CommandStringDisplayable;
 import com.blamejared.crafttweaker.api.tag.CraftTweakerTagRegistry;
@@ -26,7 +27,7 @@ import java.util.stream.Collectors;
 /**
  * @docParam this <tagmanager:items>
  */
-@ZenRegister
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @Document("vanilla/api/tag/manager/ITagManager")
 @ZenCodeType.Name("crafttweaker.api.tag.manager.ITagManager")
 public interface ITagManager<T extends MCTag> extends CommandStringDisplayable, Iterable<T> {

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/tag/manager/type/UnknownTagManager.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/tag/manager/type/UnknownTagManager.java
@@ -1,6 +1,7 @@
 package com.blamejared.crafttweaker.api.tag.manager.type;
 
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.action.tag.unknown.ActionUnknownTagAdd;
 import com.blamejared.crafttweaker.api.action.tag.unknown.ActionUnknownTagClear;
 import com.blamejared.crafttweaker.api.action.tag.unknown.ActionUnknownTagCreate;
@@ -29,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@ZenRegister
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @Document("vanilla/api/tag/manager/type/UnknownTagManager")
 @ZenCodeType.Name("crafttweaker.api.tag.manager.type.UnknownTagManager")
 public class UnknownTagManager implements ITagManager<UnknownTag> {

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/tag/type/UnknownTag.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/tag/type/UnknownTag.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.api.tag.type;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker.api.tag.MCTag;
 import com.blamejared.crafttweaker.api.tag.manager.type.UnknownTagManager;
@@ -15,7 +16,7 @@ import javax.annotation.Nonnull;
  *
  * @implNote Modders should use {@link MCTag} instead of this class for parameters as a previously unknown tag could become a known tag in the future..
  */
-@ZenRegister
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @Document("vanilla/api/tag/type/UnknownTag")
 @ZenCodeType.Name("crafttweaker.api.tag.type.UnknownTag")
 @SuppressWarnings("ClassCanBeRecord")

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/util/Many.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/util/Many.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.api.util;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker.api.bracket.CommandStringDisplayable;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
@@ -10,7 +11,7 @@ import java.util.function.Function;
 /**
  * Used to represent data with an attached percentage (think an ItemStack with a 50% chance of being outputted).
  */
-@ZenRegister
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @ZenCodeType.Name("crafttweaker.api.util.Many")
 @Document("vanilla/api/util/Many")
 public class Many<T> implements CommandStringDisplayable {

--- a/Common/src/main/java/com/blamejared/crafttweaker/impl/helper/AccessibleServerElementsProvider.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/impl/helper/AccessibleServerElementsProvider.java
@@ -19,6 +19,7 @@ public final class AccessibleServerElementsProvider implements IAccessibleServer
     private AccessibleServerElementsProvider() {
         
         this.resources = null;
+        this.registryAccess = null;
     }
     
     static IAccessibleServerElementsProvider get() {

--- a/Common/src/main/java/com/blamejared/crafttweaker/impl/plugin/crafttweaker/BuiltinCraftTweakerPlugin.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/impl/plugin/crafttweaker/BuiltinCraftTweakerPlugin.java
@@ -109,8 +109,8 @@ public final class BuiltinCraftTweakerPlugin implements ICraftTweakerPlugin {
         handler.registerParserFor(CraftTweakerConstants.DEFAULT_LOADER_NAME, "tag", new TagBracketHandler(), new IBracketParserRegistrationHandler.DumperData("tag", TagBracketHandler.getDumperData()));
         handler.registerParserFor(CraftTweakerConstants.DEFAULT_LOADER_NAME, "tagmanager", new TagManagerBracketHandler(), new IBracketParserRegistrationHandler.DumperData("tagmanager", TagManagerBracketHandler.getDumperData()));
         
-        handler.registerParserFor(CraftTweakerConstants.TAGS_LOADER_NAME, "tag", new TagBracketHandler(), new IBracketParserRegistrationHandler.DumperData("tag", TagBracketHandler.getDumperData()));
-        handler.registerParserFor(CraftTweakerConstants.TAGS_LOADER_NAME, "tagmanager", new TagManagerBracketHandler(), new IBracketParserRegistrationHandler.DumperData("tagmanager", TagManagerBracketHandler.getDumperData()));
+        handler.registerParserFor(CraftTweakerConstants.TAGS_LOADER_NAME, "tag", new TagBracketHandler());
+        handler.registerParserFor(CraftTweakerConstants.TAGS_LOADER_NAME, "tagmanager", new TagManagerBracketHandler());
     }
     
     @Override

--- a/Common/src/main/java/com/blamejared/crafttweaker/impl/plugin/crafttweaker/BuiltinCraftTweakerPlugin.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/impl/plugin/crafttweaker/BuiltinCraftTweakerPlugin.java
@@ -1,6 +1,8 @@
 package com.blamejared.crafttweaker.impl.plugin.crafttweaker;
 
 import com.blamejared.crafttweaker.api.CraftTweakerConstants;
+import com.blamejared.crafttweaker.api.bracket.BracketHandlers;
+import com.blamejared.crafttweaker.api.bracket.ResourceLocationBracketHandler;
 import com.blamejared.crafttweaker.api.bracket.custom.EnumConstantBracketHandler;
 import com.blamejared.crafttweaker.api.bracket.custom.RecipeTypeBracketHandler;
 import com.blamejared.crafttweaker.api.bracket.custom.TagBracketHandler;
@@ -65,6 +67,7 @@ public final class BuiltinCraftTweakerPlugin implements ICraftTweakerPlugin {
         
         handler.registerLoader(CraftTweakerConstants.INIT_LOADER_NAME);
         handler.registerLoader(CraftTweakerConstants.DEFAULT_LOADER_NAME);
+        handler.registerLoader(CraftTweakerConstants.TAGS_LOADER_NAME);
     }
     
     @Override
@@ -80,6 +83,7 @@ public final class BuiltinCraftTweakerPlugin implements ICraftTweakerPlugin {
         final IScriptRunModuleConfigurator defaultConfig = IScriptRunModuleConfigurator.createDefault(CraftTweakerConstants.MOD_ID);
         handler.registerConfigurator(CraftTweakerConstants.DEFAULT_LOADER_NAME, defaultConfig);
         handler.registerConfigurator(CraftTweakerConstants.INIT_LOADER_NAME, defaultConfig); // TODO("Is this valid?")
+        handler.registerConfigurator(CraftTweakerConstants.TAGS_LOADER_NAME, defaultConfig);
     }
     
     @Override
@@ -105,6 +109,8 @@ public final class BuiltinCraftTweakerPlugin implements ICraftTweakerPlugin {
         handler.registerParserFor(CraftTweakerConstants.DEFAULT_LOADER_NAME, "tag", new TagBracketHandler(), new IBracketParserRegistrationHandler.DumperData("tag", TagBracketHandler.getDumperData()));
         handler.registerParserFor(CraftTweakerConstants.DEFAULT_LOADER_NAME, "tagmanager", new TagManagerBracketHandler(), new IBracketParserRegistrationHandler.DumperData("tagmanager", TagManagerBracketHandler.getDumperData()));
         
+        handler.registerParserFor(CraftTweakerConstants.TAGS_LOADER_NAME, "tag", new TagBracketHandler(), new IBracketParserRegistrationHandler.DumperData("tag", TagBracketHandler.getDumperData()));
+        handler.registerParserFor(CraftTweakerConstants.TAGS_LOADER_NAME, "tagmanager", new TagManagerBracketHandler(), new IBracketParserRegistrationHandler.DumperData("tagmanager", TagManagerBracketHandler.getDumperData()));
     }
     
     @Override

--- a/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/tags/MixinTagManager.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/tags/MixinTagManager.java
@@ -1,0 +1,56 @@
+package com.blamejared.crafttweaker.mixin.common.transform.tags;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
+import com.blamejared.crafttweaker.api.tag.CraftTweakerTagRegistry;
+import com.blamejared.crafttweaker.api.zencode.scriptrun.ScriptRunConfiguration;
+import com.blamejared.crafttweaker.platform.helper.IAccessibleServerElementsProvider;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.tags.TagManager;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+@Mixin(TagManager.class)
+public class MixinTagManager {
+    
+    @Shadow
+    private List<TagManager.LoadResult<?>> results;
+    
+    @Shadow
+    @Final
+    private RegistryAccess registryAccess;
+    
+    @ModifyArg(method = "reload", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/CompletableFuture;thenAcceptAsync(Ljava/util/function/Consumer;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"))
+    public <T> Consumer<? super T> modifyArg(Consumer<? super T> action) {
+        
+        return action.andThen(o -> {
+            CraftTweakerTagRegistry.INSTANCE.bind(results, new CraftTweakerTagRegistry.BindContext().registerKnownManagers(false));
+    
+            IAccessibleServerElementsProvider asep = CraftTweakerAPI.getAccessibleElementsProvider().server();
+            asep.registryAccess(this.registryAccess);
+    
+    
+            final ScriptRunConfiguration configuration = new ScriptRunConfiguration(
+                    CraftTweakerConstants.TAGS_LOADER_NAME,
+                    CraftTweakerConstants.RELOAD_LISTENER_SOURCE_ID, // TODO("Custom load source?")
+                    ScriptRunConfiguration.RunKind.EXECUTE
+            );
+    
+            try {
+                CraftTweakerAPI.getScriptRunManager()
+                        .createScriptRun(configuration)
+                        .execute();
+            } catch(final Throwable e) {
+                CraftTweakerAPI.LOGGER.error("Unable to run tag scripts due to an error", e);
+            }
+            asep.registryAccess(null);
+        });
+    }
+    
+}

--- a/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/tags/MixinTagManager.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/mixin/common/transform/tags/MixinTagManager.java
@@ -27,7 +27,7 @@ public class MixinTagManager {
     private RegistryAccess registryAccess;
     
     @ModifyArg(method = "reload", at = @At(value = "INVOKE", target = "Ljava/util/concurrent/CompletableFuture;thenAcceptAsync(Ljava/util/function/Consumer;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;"))
-    public <T> Consumer<? super T> modifyArg(Consumer<? super T> action) {
+    public <T> Consumer<? super T> crafttweaker$appendConsumer(Consumer<? super T> action) {
         
         return action.andThen(o -> {
             CraftTweakerTagRegistry.INSTANCE.bind(results, new CraftTweakerTagRegistry.BindContext().registerKnownManagers(false));

--- a/Common/src/main/java/com/blamejared/crafttweaker/natives/resource/ExpandResourceLocation.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/natives/resource/ExpandResourceLocation.java
@@ -1,5 +1,6 @@
 package com.blamejared.crafttweaker.natives.resource;
 
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
 import com.blamejared.crafttweaker.api.annotation.ZenRegister;
 import com.blamejared.crafttweaker.api.data.StringData;
 import com.blamejared.crafttweaker.api.data.base.IData;
@@ -9,7 +10,7 @@ import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistratio
 import net.minecraft.resources.ResourceLocation;
 import org.openzen.zencode.java.ZenCodeType;
 
-@ZenRegister
+@ZenRegister(loaders = {CraftTweakerConstants.DEFAULT_LOADER_NAME, CraftTweakerConstants.TAGS_LOADER_NAME})
 @Document("vanilla/api/resource/ResourceLocation")
 @NativeTypeRegistration(value = ResourceLocation.class, zenCodeName = ExpandResourceLocation.ZC_CLASS_NAME, constructors = @NativeConstructor({@NativeConstructor.ConstructorParameter(name = "namespace", type = String.class, description = "Usually a ModId"), @NativeConstructor.ConstructorParameter(name = "path", type = String.class, description = "May only contain lower-cased alphanumeric values, as well as / and _")}))
 public class ExpandResourceLocation {

--- a/Common/src/main/resources/crafttweaker.mixins.json
+++ b/Common/src/main/resources/crafttweaker.mixins.json
@@ -32,6 +32,7 @@
     "common.access.world.biome.AccessBiome",
     "common.transform.item.MixinIngredient",
     "common.transform.item.MixinIngredientTagValue",
+    "common.transform.tags.MixinTagManager",
     "common.transform.world.level.MixinServerLevel"
   ],
   "client": [


### PR DESCRIPTION
In some cases recipes do a tag lookup to see if they should be added, like only adding a recipe if the `minecraft:ingots/copper` tag is not empty (so there is copper ingots in the game).

The issue is, CraftTweaker scripts usually load after recipes are added, so it is possible for a recipe to expect the copper tag to have items, but then a script may clear the copper tag.

This is a solution to that, scripters can use:
```zenscript
#loader tags

<tag:minecraft:ingots/copper>.addId(<resource:minecraft:white_wool>);
```
to add items to a tag (or remove from a tag) before conditional recipes query the tags.

While moving to this loader will be the safest option for tag modifications, it is only required if scripters actually run into issues (which none have so far).


More information about the loader:

The only classes available are:
```zenscript
ResourceLocation
Many
UnknownTag
MCTag
UnknownTagManager
ITagManager
TagManager
INumberData
IData
ICollectionData
CommandStringDisplayable
```
and the only brackets that are registered are:
```zenscript
<tag>
<tagmanager>
<resource>
```

You can't do anything else with this loader besides modify tags, and query tags (which will only give you the ID, not an Item for example)