### PR TITLE
Add .zs.txt warning

### DIFF
--- a/Common/src/main/java/com/blamejared/crafttweaker/api/zencode/scriptrun/IScriptRunManager.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/zencode/scriptrun/IScriptRunManager.java
@@ -21,6 +21,10 @@ public interface IScriptRunManager {
      * report a {@linkplain java.nio.file.attribute.BasicFileAttributes#isRegularFile() regular file} and whose
      * {@linkplain Path#getFileName() file name} ends with {@code .zs}.</p>
      *
+     * <p>During the discovery phase, any file with a
+     * {@linkplain ScriptDiscoveryConfiguration.SuspiciousNamesBehavior suspicious name} will raise a warning in the
+     * logs.</p>
+     *
      * @param configuration The configuration of the script run.
      *
      * @return A script run that carries out the specified operations.
@@ -38,6 +42,10 @@ public interface IScriptRunManager {
      * {@linkplain java.nio.file.attribute.BasicFileAttributes#isRegularFile() regular file} and whose
      * {@linkplain Path#getFileName() file name} ends with {@code .zs}.</p>
      *
+     * <p>During the discovery phase, any file with a
+     * {@linkplain ScriptDiscoveryConfiguration.SuspiciousNamesBehavior suspicious name} will raise a warning in the
+     * logs.</p>
+     *
      * @param root          The root {@link Path} from which CraftTweaker should look for scripts.
      * @param configuration The configuration of the script run.
      *
@@ -46,6 +54,25 @@ public interface IScriptRunManager {
      * @since 9.1.0
      */
     IScriptRun createScriptRun(final Path root, final ScriptRunConfiguration configuration);
+    
+    /**
+     * Creates an {@link IScriptRun} with the specified {@link ScriptRunConfiguration} executing all valid scripts
+     * discovered according to the given {@link ScriptDiscoveryConfiguration} from the given {@code root}.
+     *
+     * <p>In this instance, a valid script file is identified by a {@link Path} whose
+     * {@link java.nio.file.attribute.BasicFileAttributes} report a
+     * {@linkplain java.nio.file.attribute.BasicFileAttributes#isRegularFile() regular file} and whose
+     * {@linkplain Path#getFileName() file name} ends with {@code .zs}.</p>
+     *
+     * @param root                   The root {@link Path} from which CraftTweaker should look for scripts.
+     * @param discoveryConfiguration The configuration for the discovery process.
+     * @param runConfiguration       The configuration of the script run.
+     *
+     * @return A script run that carries out the specified operations.
+     *
+     * @since 10.1.0
+     */
+    IScriptRun createScriptRun(final Path root, final ScriptDiscoveryConfiguration discoveryConfiguration, final ScriptRunConfiguration runConfiguration);
     
     /**
      * Creates an {@link IScriptRun} with the specified {@link ScriptRunConfiguration} executing the script files in

--- a/Common/src/main/java/com/blamejared/crafttweaker/api/zencode/scriptrun/ScriptDiscoveryConfiguration.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/api/zencode/scriptrun/ScriptDiscoveryConfiguration.java
@@ -1,0 +1,84 @@
+package com.blamejared.crafttweaker.api.zencode.scriptrun;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Holds the configuration that should be followed during automatic script discovery for the creation of a
+ * {@link IScriptRun}.
+ *
+ * @param suspiciousNamesBehavior The behavior to use whenever a file with a
+ *                                {@linkplain SuspiciousNamesBehavior suspicious name} is encountered during discovery.
+ * @param retainer                The {@link DiscoveryRetainer} to invoke to store the list of discovered files.
+ *
+ * @since 10.1.0
+ */
+public record ScriptDiscoveryConfiguration(SuspiciousNamesBehavior suspiciousNamesBehavior,
+                                           DiscoveryRetainer retainer) {
+    
+    /**
+     * Creates a {@link ScriptDiscoveryConfiguration} with the given behavior and a no-op {@link DiscoveryRetainer}.
+     *
+     * @param suspiciousNamesBehavior The behavior to use whenever a file with a
+     *                                {@linkplain SuspiciousNamesBehavior suspicious name} is encountered during
+     *                                discovery.
+     *
+     * @since 10.1.0
+     */
+    public ScriptDiscoveryConfiguration(final SuspiciousNamesBehavior suspiciousNamesBehavior) {
+        
+        this(suspiciousNamesBehavior, (root, files) -> {});
+    }
+    
+    /**
+     * Specifies the behavior to be used when a file with a suspicious name is encountered.
+     *
+     * <p>A file is deemed to be with a suspicious name if its name ends with {@code .zs.txt}, as it indicates that the
+     * user has likely made a mistake when creating the file.</p>
+     *
+     * @since 10.1.0
+     */
+    public enum SuspiciousNamesBehavior {
+        /**
+         * Indicates that any file with a suspicious name should be ignored.
+         *
+         * @since 10.1.0
+         */
+        IGNORE,
+        /**
+         * Indicates that any file with a suspicious name should raise a warning in the logs, but should otherwise be
+         * ignored for the purposes of loading.
+         *
+         * @since 10.1.0
+         */
+        WARN
+    }
+    
+    /**
+     * Represents a callback that can be used to retain the results of the discovery process.
+     *
+     * <p>This callback will be invoked once at the end of the discovery phase, allowing for further operations to be
+     * performed with the script files that the automatic discovery process has identified. In particular, this callback
+     * is guaranteed to be invoked before a {@link IScriptRun} instance will be created.</p>
+     *
+     * <p>This is a {@linkplain FunctionalInterface functional interface} whose functional method is
+     * {@link #retain(Path, List)}.</p>
+     *
+     * @since 10.1.0
+     */
+    @FunctionalInterface
+    public interface DiscoveryRetainer {
+        
+        /**
+         * Performs the retaining operations that are deemed necessary.
+         *
+         * @param root             The path from which script discovery has begun.
+         * @param discoveryResults The paths that have been discovered and deemed valid scripts.
+         *
+         * @since 10.1.0
+         */
+        void retain(final Path root, final List<Path> discoveryResults);
+        
+    }
+    
+}

--- a/Common/src/main/java/com/blamejared/crafttweaker/impl/script/scriptrun/SuspiciousAwarePathList.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/impl/script/scriptrun/SuspiciousAwarePathList.java
@@ -1,0 +1,359 @@
+package com.blamejared.crafttweaker.impl.script.scriptrun;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+final class SuspiciousAwarePathList implements List<Path> {
+    
+    @SuppressWarnings("ClassCanBeRecord")
+    private static final class SuspiciousAwarePathListIterator implements ListIterator<Path> {
+        
+        private final ListIterator<Path> delegate;
+        private final PathMatcher suspiciousMatcher;
+        
+        SuspiciousAwarePathListIterator(final ListIterator<Path> delegate, final PathMatcher suspiciousMatcher) {
+            
+            this.delegate = delegate;
+            this.suspiciousMatcher = suspiciousMatcher;
+        }
+        
+        @Override
+        public boolean hasNext() {
+            
+            return this.delegate.hasNext();
+        }
+        
+        @Override
+        public Path next() {
+            
+            return this.delegate.next();
+        }
+        
+        @Override
+        public boolean hasPrevious() {
+            
+            return this.delegate.hasPrevious();
+        }
+        
+        @Override
+        public Path previous() {
+            
+            return this.delegate.previous();
+        }
+        
+        @Override
+        public int nextIndex() {
+            
+            return this.delegate.nextIndex();
+        }
+        
+        @Override
+        public int previousIndex() {
+            
+            return this.delegate.previousIndex();
+        }
+        
+        @Override
+        public void remove() {
+            
+            this.delegate.remove();
+        }
+        
+        @Override
+        public void forEachRemaining(final Consumer<? super Path> action) {
+            
+            this.delegate.forEachRemaining(action);
+        }
+        
+        @Override
+        public void set(final Path path) {
+            
+            if(this.suspiciousMatcher.matches(path)) {
+                throw new IllegalArgumentException("Suspicious element " + path);
+            }
+            
+            this.delegate.set(path);
+        }
+        
+        @Override
+        public void add(final Path path) {
+            
+            if(this.suspiciousMatcher.matches(path)) {
+                throw new IllegalArgumentException("Suspicious element " + path);
+            }
+            
+            this.delegate.add(path);
+        }
+        
+    }
+    
+    private final List<Path> delegate;
+    private final PathMatcher suspiciousMatcher;
+    private final Consumer<Path> logger;
+    
+    private SuspiciousAwarePathList(final List<Path> delegate, final PathMatcher suspiciousMatcher, final Consumer<Path> logger) {
+        
+        this.delegate = delegate;
+        this.suspiciousMatcher = suspiciousMatcher;
+        this.logger = logger;
+    }
+    
+    static SuspiciousAwarePathList of(final PathMatcher suspiciousMatcher, final Consumer<Path> logger) {
+        
+        return new SuspiciousAwarePathList(new ArrayList<>(), suspiciousMatcher, logger);
+    }
+    
+    
+    @Override
+    public boolean add(final Path path) {
+        
+        if(this.suspiciousMatcher.matches(path)) {
+            this.logger.accept(path);
+            return false;
+        }
+        
+        return this.delegate.add(path);
+    }
+    
+    @Override
+    public boolean addAll(@NotNull final Collection<? extends Path> c) {
+        
+        boolean result = false;
+        for(final Path p : c) {
+            result |= this.add(p);
+        }
+        return result;
+    }
+    
+    @Override
+    public boolean addAll(final int index, @NotNull final Collection<? extends Path> c) {
+        
+        boolean result = false;
+        int idx = index;
+        for(final Path p : c) {
+            final boolean r = this.addImpl(idx, p);
+            result |= r;
+            if(r) {
+                idx++;
+            }
+        }
+        return result;
+    }
+    
+    @Override
+    public int size() {
+        
+        return this.delegate.size();
+    }
+    
+    @Override
+    public boolean isEmpty() {
+        
+        return this.delegate.isEmpty();
+    }
+    
+    @Override
+    public boolean contains(final Object o) {
+        
+        return this.delegate.contains(o);
+    }
+    
+    @NotNull
+    @Override
+    public Iterator<Path> iterator() {
+        
+        return this.delegate.iterator();
+    }
+    
+    @NotNull
+    @Override
+    public Object[] toArray() {
+        
+        return this.delegate.toArray();
+    }
+    
+    @NotNull
+    @Override
+    public <T> T[] toArray(@NotNull final T[] a) {
+        
+        return this.delegate.toArray(a);
+    }
+    
+    @Override
+    public boolean remove(final Object o) {
+        
+        return this.delegate.remove(o);
+    }
+    
+    @Override
+    @SuppressWarnings("SlowListContainsAll")
+    public boolean containsAll(@NotNull final Collection<?> c) {
+        
+        return this.delegate.containsAll(c);
+    }
+    
+    @Override
+    public boolean removeAll(@NotNull final Collection<?> c) {
+        
+        return this.delegate.removeAll(c);
+    }
+    
+    @Override
+    public boolean retainAll(@NotNull final Collection<?> c) {
+        
+        return this.delegate.retainAll(c);
+    }
+    
+    @Override
+    public void clear() {
+        
+        this.delegate.clear();
+    }
+    
+    @Override
+    public Path get(final int index) {
+        
+        return this.delegate.get(index);
+    }
+    
+    @Override
+    public Path set(final int index, final Path element) {
+        
+        if(this.suspiciousMatcher.matches(element)) {
+            throw new IllegalArgumentException("Suspicious element " + element);
+        }
+        
+        return this.delegate.set(index, element);
+    }
+    
+    @Override
+    public void add(final int index, final Path element) {
+        
+        if(!this.addImpl(index, element)) {
+            throw new IllegalArgumentException("Suspicious element " + element);
+        }
+    }
+    
+    @Override
+    public Path remove(final int index) {
+        
+        return this.delegate.remove(index);
+    }
+    
+    @Override
+    public int indexOf(final Object o) {
+        
+        return this.delegate.indexOf(o);
+    }
+    
+    @Override
+    public int lastIndexOf(final Object o) {
+        
+        return this.delegate.lastIndexOf(o);
+    }
+    
+    @NotNull
+    @Override
+    public ListIterator<Path> listIterator() {
+        
+        return new SuspiciousAwarePathListIterator(this.delegate.listIterator(), this.suspiciousMatcher);
+    }
+    
+    @NotNull
+    @Override
+    public ListIterator<Path> listIterator(final int index) {
+        
+        return new SuspiciousAwarePathListIterator(this.delegate.listIterator(index), this.suspiciousMatcher);
+    }
+    
+    @NotNull
+    @Override
+    public List<Path> subList(final int fromIndex, final int toIndex) {
+        
+        return new SuspiciousAwarePathList(this.delegate.subList(fromIndex, toIndex), this.suspiciousMatcher, this.logger);
+    }
+    
+    @Override
+    public void replaceAll(final UnaryOperator<Path> operator) {
+        
+        this.delegate.replaceAll(it -> {
+            final Path result = operator.apply(it);
+            if(this.suspiciousMatcher.matches(result)) {
+                throw new UnsupportedOperationException("Cannot replace element %s with suspicious element %s".formatted(it, result));
+            }
+            return result;
+        });
+    }
+    
+    @Override
+    public void sort(final Comparator<? super Path> c) {
+        
+        this.delegate.sort(c);
+    }
+    
+    @Override
+    public Spliterator<Path> spliterator() {
+        
+        return this.delegate.spliterator();
+    }
+    
+    @Override
+    public <T> T[] toArray(final IntFunction<T[]> generator) {
+        
+        return this.delegate.toArray(generator);
+    }
+    
+    @Override
+    public boolean removeIf(final Predicate<? super Path> filter) {
+        
+        return this.delegate.removeIf(filter);
+    }
+    
+    @Override
+    public Stream<Path> stream() {
+        
+        return this.delegate.stream();
+    }
+    
+    @Override
+    public Stream<Path> parallelStream() {
+        
+        return this.delegate.parallelStream();
+    }
+    
+    @Override
+    public void forEach(final Consumer<? super Path> action) {
+        
+        this.delegate.forEach(action);
+    }
+    
+    private boolean addImpl(final int index, final Path p) {
+        
+        if(this.suspiciousMatcher.matches(p)) {
+            this.logger.accept(p);
+            return false;
+        }
+        
+        try {
+            this.delegate.add(index, p);
+            return true;
+        } catch(final IllegalArgumentException e) {
+            return false;
+        }
+    }
+    
+}


### PR DESCRIPTION
This PR aims to fix an issue that has always existed, namely people using .zs.txt for their file names and then wondering why nothing is loaded. With this, a warning is logged to crafttweaker.log stating the name of the file that was skipped, so that they can realize their mistake.

A new API has also been provided that allows integration writers to enable or suppress this behavior as needed during the discovery phase, while also providing a mechanism to retain the list of files discovered, which allows people to avoid having to reimplement the discovery process themselves in that case (which is something we also had to do).

Differently from #1607 and #1608, this API causes no breaking changes.