### PR TITLE
Enable following symlinks when reading files

### DIFF
--- a/Common/src/main/java/com/blamejared/crafttweaker/impl/script/scriptrun/ScriptRunManager.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/impl/script/scriptrun/ScriptRunManager.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/Common/src/main/java/com/blamejared/crafttweaker/impl/script/scriptrun/ScriptRunManager.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/impl/script/scriptrun/ScriptRunManager.java
@@ -18,6 +18,7 @@ import org.openzen.zencode.shared.SourceFile;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -143,7 +144,7 @@ public final class ScriptRunManager implements IScriptRunManager {
             final PathMatcher combinedMatcher = it -> correctMatcher.matches(it) || suspiciousMatcher.matches(it);
             
             final List<Path> files = SuspiciousAwarePathList.of(suspiciousMatcher, this.makeSuspiciousConsumer(root, discoveryConfiguration));
-            Files.walkFileTree(root, FileGathererHelper.of(combinedMatcher, files::add));
+            Files.walkFileTree(root, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, FileGathererHelper.of(combinedMatcher, files::add));
             
             discoveryConfiguration.retainer().retain(root, files);
             

--- a/buildSrc/src/main/kotlin/com/blamejared/crafttweaker/gradle/DefaultPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/blamejared/crafttweaker/gradle/DefaultPlugin.kt
@@ -65,12 +65,6 @@ class DefaultPlugin : Plugin<Project> {
             this.add(this.maven("https://maven.parchmentmc.org/") {
                 name = "ParchmentMC"
             })
-            this.add(this.maven("https://dvs1.progwml6.com/files/maven/") {
-                name = "JEI"
-                content {
-                    includeGroup("mezz.jei")
-                }
-            })
             this.add(this.maven("https://maven.shedaniel.me/") {
                 name = "REI"
                 content {


### PR DESCRIPTION
I could not build this locally to test it fully, but this should make it possible to symlink _within_ the `scripts` directory.  It doesn't allow the `scripts` directory itself to be a symlink as the `createDirectory` called on init will throw an error if it's a symlink.