### PR TITLE
fix moon phase

### DIFF
--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/MCWorld.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/world/MCWorld.java
@@ -100,7 +100,7 @@ public class MCWorld extends MCBlockAccess implements IWorld {
 
 	@Override
 	public int getMoonPhase() {
-		return world.provider.getMoonPhase(this.getWorldTime());
+		return world.provider.getMoonPhase(world.getWorldTime());
 	}
 
 	@Override


### PR DESCRIPTION
The getmoonphase() originally used totalworldtime, which prevented the /time command from changing the obtained moonphase in the game