### PR TITLE
Fix symlinked scripts directory throwing error

### DIFF
--- a/Common/src/main/java/com/blamejared/crafttweaker/CraftTweakerCommon.java
+++ b/Common/src/main/java/com/blamejared/crafttweaker/CraftTweakerCommon.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
@@ -37,8 +38,11 @@ public class CraftTweakerCommon {
         try {
             Files.createDirectories(CraftTweakerAPI.getScriptsDirectory());
         } catch(IOException e) {
-            final String path = CraftTweakerAPI.getScriptsDirectory().toAbsolutePath().toString();
-            throw new IllegalStateException("Could not create Directory " + path);
+            // We don't really care if it exists already
+            if (!(e instanceof FileAlreadyExistsException)) {
+                final String path = CraftTweakerAPI.getScriptsDirectory().toAbsolutePath().toString();
+                throw new IllegalStateException("Could not create Directory " + path);
+            }
         }
         CraftTweakerEarlyInit.run();
         


### PR DESCRIPTION
When the scripts directory is a symlink, starting up Minecraft will throw `java.lang.IllegalStateException: Could not create Directory <scriptsDirectoryPath>`.

This is caused by `Files.createDirectories`'s lack of support for following symlinks. When running into a symlink, a `FileAlreadyExistsException`. When that is thrown, I've skipped throwing the exception.