### PR TITLE
Expand support for EnchantmentType

### DIFF
--- a/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/DumpCommands.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl/commands/crafttweaker/DumpCommands.java
@@ -12,6 +12,7 @@ import com.blamejared.crafttweaker.impl.tag.manager.TagManager;
 import com.blamejared.crafttweaker.impl.tag.registry.CrTTagRegistry;
 import com.blamejared.crafttweaker.impl_native.villager.ExpandVillagerProfession;
 import com.mojang.authlib.GameProfile;
+import net.minecraft.enchantment.EnchantmentType;
 import net.minecraft.entity.merchant.villager.VillagerTrades;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.registry.Registry;
@@ -201,6 +202,18 @@ public final class DumpCommands {
             
             
             CommandUtilities.send(CommandUtilities.color("Tag Contents list generated! Check the crafttweaker.log file!", TextFormatting.GREEN), player);
+            return 0;
+        });
+        
+        CTCommands.registerDump("enchantment_types", "Outputs all EnchantmentType values", ctx -> {
+            
+            CraftTweakerAPI.logDump("\nAll EnchantmentType Values");
+            
+            for (EnchantmentType type : EnchantmentType.values()) {
+                
+                CraftTweakerAPI.logDump("\t- " + type.name());
+            }
+            
             return 0;
         });
     }

--- a/src/main/java/com/blamejared/crafttweaker/impl_native/enchantment/ExpandEnchantment.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl_native/enchantment/ExpandEnchantment.java
@@ -7,6 +7,7 @@ import com.blamejared.crafttweaker.impl.util.text.MCTextComponent;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
 import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
@@ -33,6 +34,18 @@ public class ExpandEnchantment {
     public static Enchantment.Rarity getRarity(Enchantment internal) {
         
         return internal.getRarity();
+    }
+    
+    /**
+     * Gets the EnchantmentType of this Enchantment.
+     *
+     * @return The EnchantmentType of this Enchantment.
+     */
+    @ZenCodeType.Method
+    @ZenCodeType.Getter("type")
+    public static EnchantmentType getType(Enchantment internal) {
+        
+        return internal.type;
     }
     
     /**

--- a/src/main/java/com/blamejared/crafttweaker/impl_native/enchantment/ExpandEnchantmentType.java
+++ b/src/main/java/com/blamejared/crafttweaker/impl_native/enchantment/ExpandEnchantmentType.java
@@ -3,10 +3,14 @@ package com.blamejared.crafttweaker.impl_native.enchantment;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
 import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentType;
 import net.minecraft.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
 import org.openzen.zencode.java.ZenCodeType;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -28,6 +32,72 @@ public class ExpandEnchantmentType {
         return internal.canEnchantItem(itemIn);
     }
     
+    /**
+     * Creates a new List of MCEnchantment that define the EnchantmentType as their type.
+     *
+     * @return A new List of MCEnchantment that define the EnchantmentType as their type.
+     */
+    @ZenCodeType.Method
+    public static List<Enchantment> getEnchantments(EnchantmentType internal) {
+        
+        final List<Enchantment> enchantments = new ArrayList<>();
+        
+        for (Enchantment enchantment : ForgeRegistries.ENCHANTMENTS) {
+            
+            if (internal == enchantment.type) {
+                
+                enchantments.add(enchantment);
+            }
+        }
+        
+        return enchantments;
+    }
+    
+    /**
+     * Creates a new List of ItemDefinition that are valid for this EnchantmentType.
+     *
+     * @return A new List of ItemDefinition that are valid for this EnchantmentType.
+     */
+    @ZenCodeType.Method
+    public static List<Item> getItems(EnchantmentType internal) {
+        
+        final List<Item> items = new ArrayList<>();
+        
+        for (Item item : ForgeRegistries.ITEMS) {
+            
+            if (internal.canEnchantItem(item)) {
+                
+                items.add(item);
+            }
+        }
+        
+        return items;
+    }
+    
+    /**
+     * Creates a new List of EnchantmentType that are applicable to an item.
+     *
+     * @param item The item to calculate applicable enchantment types for.
+     *
+     * @return A new List of EnchantmentType that are applicable to an item.
+     *
+     * @docParam item <item:minecraft:diamond_sword>
+     */
+    @ZenCodeType.StaticExpansionMethod
+    public static List<EnchantmentType> getTypesForItem(Item item) {
+        
+        final List<EnchantmentType> validTypes = new ArrayList<>();
+        
+        for (EnchantmentType type : EnchantmentType.values()) {
+            
+            if (type.canEnchantItem(item)) {
+                
+                validTypes.add(type);
+            }
+        }
+        
+        return validTypes;
+    }
     
     /**
      * Creates a new EnchantmentType with the given name and given can enchantment predicate.


### PR DESCRIPTION
This PR expands the support for EnchantmentType in the following ways.

- Enchantment types can now be dumped using `/ct dump enchantment_types`
- The type of an enchantment is now exposed. Example: `<enchantment:minecraft:sharpness>.type`
- Helper to get all enchantments of a type. Example: `EnchantmentType.WEAPON.getEnchantments()`
- Helper to get all items of a type. Example: `EnchantmentType.DIGGER.getItems()`
- Helper to get all types for an item. Example `EnchantmentType.getTypesForItem(<item:minecraft:diamond_sword>)`

This following example script was used to validate the changes and new features.

```zenscript
import crafttweaker.api.game.MCGame;
import crafttweaker.api.enchantment.MCEnchantment;
import crafttweaker.api.enchantment.EnchantmentType;
import stdlib.List;

// MCEnchantment now has a getter for its EnchantmentType. The below example creates a 
// map of every enchantment for a given type and prints the results.
var enchantmentsByType = {} as List<MCEnchantment>[EnchantmentType];

for enchantment in game.enchantments {

  var enchantmentsOfType = enchantment.type in enchantmentsByType ? enchantmentsByType[enchantment.type] : new List<MCEnchantment>();
  enchantmentsOfType.add(enchantment);
  enchantmentsByType[enchantment.type] = enchantmentsOfType;
}

println("Enchantments by Type");
for type, enchantments in enchantmentsByType {

  println(type);
  println("==========");
  
  for enchantment in enchantments {
  
    println(enchantment.registryName);
  }
  
  println("");
}

// A new helper method that allows you to get every enchantment for a given type.
println("All WEAPON Enchantments");
for weaponEnchantment in EnchantmentType.WEAPON.getEnchantments() {
  println(weaponEnchantment.registryName);
}
println("");

// A new helper method that allows you to get every item for a given type.
println("All DIGGER Items");
for diggerItem in EnchantmentType.DIGGER.getItems() {
  println(diggerItem.registryName);
}
println("");

// A new helper method that allows you to get every type that applies to an item.
println("Diamond Sword Types");
for type in EnchantmentType.getTypesForItem(<item:minecraft:diamond_sword>) {
  println(type);
}
println("");
```