### PR TITLE
Additional support for containers.

### DIFF
--- a/common/src/main/java/com/blamejared/crafttweaker/natives/world/ExpandBlockContainerSingleItem.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/natives/world/ExpandBlockContainerSingleItem.java
@@ -1,0 +1,40 @@
+package com.blamejared.crafttweaker.natives.world;
+
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.ticks.ContainerSingleItem;
+import org.openzen.zencode.java.ZenCodeType;
+
+@ZenRegister
+@Document("vanilla/api/world/BlockContainerSingleItem")
+@NativeTypeRegistration(value = ContainerSingleItem.BlockContainerSingleItem.class, zenCodeName = "crafttweaker.api.world.BlockContainerSingleItem")
+public class ExpandBlockContainerSingleItem {
+    
+    /**
+     * Gets the BlockEntity that holds the container.
+     *
+     * @return The BlockEntity that holds the container.
+     */
+    @ZenCodeType.Method
+    public static BlockEntity getContainerBlockEntity(ContainerSingleItem.BlockContainerSingleItem internal) {
+        
+        return internal.getContainerBlockEntity();
+    }
+    
+    /**
+     * Checks if the player container is still valid for a player to interact with.
+     *
+     * @param player The player interacting with the container.
+     *
+     * @return Whether the player can still access the container.
+     */
+    @ZenCodeType.Method
+    public static boolean stillValid(ContainerSingleItem internal, Player player) {
+        
+        return internal.stillValid(player);
+    }
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/natives/world/ExpandContainerSingleItem.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/natives/world/ExpandContainerSingleItem.java
@@ -1,0 +1,60 @@
+package com.blamejared.crafttweaker.natives.world;
+
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.ticks.ContainerSingleItem;
+import org.openzen.zencode.java.ZenCodeType;
+
+@ZenRegister
+@Document("vanilla/api/world/ContainerSingleItem")
+@NativeTypeRegistration(value = ContainerSingleItem.class, zenCodeName = "crafttweaker.api.world.ContainerSingleItem")
+public class ExpandContainerSingleItem {
+    
+    /**
+     * Gets the only item held by the container.
+     *
+     * @return The item held by the container.
+     */
+    @ZenCodeType.Method
+    public static ItemStack getTheItem(ContainerSingleItem internal) {
+        
+        return internal.getTheItem();
+    }
+    
+    /**
+     * Sets the only item held by the container.
+     *
+     * @param stack The new item for te container to hold.
+     */
+    @ZenCodeType.Method
+    public static void setTheItem(ContainerSingleItem internal, ItemStack stack) {
+        
+        internal.setTheItem(stack);
+    }
+    
+    /**
+     * Removes up to the specified amount of the contained item.
+     *
+     * @param amount The maximum amount of the item to split off from the contained item.
+     *
+     * @return The item that was split from the contained item.
+     */
+    @ZenCodeType.Method
+    public static ItemStack splitTheItem(ContainerSingleItem internal, int amount) {
+        
+        return internal.splitTheItem(amount);
+    }
+    
+    /**
+     * Removes the item stored by the container.
+     *
+     * @return The new copy of the removed item.
+     */
+    public static ItemStack removeTheItem(ContainerSingleItem internal) {
+        
+        return internal.removeTheItem();
+    }
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/natives/world/ExpandRandomizableContainer.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/natives/world/ExpandRandomizableContainer.java
@@ -1,0 +1,102 @@
+package com.blamejared.crafttweaker.natives.world;
+
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.RandomizableContainer;
+import net.minecraft.world.level.storage.loot.LootTable;
+import org.openzen.zencode.java.ZenCodeType;
+
+@ZenRegister
+@Document("vanilla/api/world/RandomizableContainer")
+@NativeTypeRegistration(value = RandomizableContainer.class, zenCodeName = "crafttweaker.api.world.RandomizableContainer")
+public class ExpandRandomizableContainer {
+    
+    /**
+     * Gets the loot table used by the container.
+     *
+     * @return The loot table used by the container.
+     */
+    @ZenCodeType.Method
+    @ZenCodeType.Getter("lootTable")
+    @ZenCodeType.Nullable
+    public static ResourceKey<LootTable> getLootTable(RandomizableContainer internal) {
+        
+        return internal.getLootTable();
+    }
+    
+    /**
+     * Sets the loot table used by the container.
+     *
+     * @param lootTable The new loot table for the container to use.
+     */
+    @ZenCodeType.Method
+    @ZenCodeType.Setter("lootTable")
+    public static void setLootTable(RandomizableContainer internal, ResourceKey<LootTable> lootTable) {
+        
+        internal.setLootTable(lootTable);
+    }
+    
+    /**
+     * Sets the loot table used by the container.
+     *
+     * @param lootTable The new loot table for the container to use.
+     * @param seed      The seed for the loot table to use.
+     */
+    @ZenCodeType.Method
+    public static void setLootTable(RandomizableContainer internal, ResourceKey<LootTable> lootTable, long seed) {
+        
+        internal.setLootTable(lootTable, seed);
+    }
+    
+    /**
+     * Sets the loot table used by the container.
+     *
+     * @param lootTable The new loot table for the container to use.
+     */
+    @ZenCodeType.Method
+    public static void setLootTable(RandomizableContainer internal, ResourceLocation lootTable) {
+        
+        internal.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, lootTable));
+    }
+    
+    /**
+     * Sets the loot table used by the container.
+     *
+     * @param lootTable The new loot table for the container to use.
+     * @param seed      The seed for the loot table to use.
+     */
+    @ZenCodeType.Method
+    public static void setLootTable(RandomizableContainer internal, ResourceLocation lootTable, long seed) {
+        
+        internal.setLootTable(ResourceKey.create(Registries.LOOT_TABLE, lootTable), seed);
+    }
+    
+    /**
+     * Gets the seed used by the loot table.
+     *
+     * @return The seed used by the loot table.
+     */
+    @ZenCodeType.Method
+    @ZenCodeType.Getter("lootSeed")
+    public static long getLootTableSeed(RandomizableContainer internal) {
+        
+        return internal.getLootTableSeed();
+    }
+    
+    /**
+     * Sets the seed used by the loot table.
+     *
+     * @param seed The seed for the loot table to use.
+     */
+    @ZenCodeType.Method
+    @ZenCodeType.Setter("lootSeed")
+    public static void setLootTableSeed(RandomizableContainer internal, long seed) {
+        
+        internal.setLootTableSeed(seed);
+    }
+    
+}

--- a/dev_scripts/events/misc.zs
+++ b/dev_scripts/events/misc.zs
@@ -7,6 +7,8 @@ import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.world.InteractionResultHolder;
 import crafttweaker.neoforge.api.event.item.ItemTossEvent;
 import crafttweaker.neoforge.api.event.interact.RightClickBlockEvent;
+import crafttweaker.api.world.RandomizableContainer;
+import crafttweaker.api.block.entity.BlockEntity;
 
 events.register<PotionBrewEventPre>(event => {
     println("PotionBrewEventPre fired");
@@ -37,4 +39,21 @@ events.register<ArrowNockEvent>(event => {
 
 events.register<RightClickBlockEvent>(event => {
     println("called thing");
+});
+
+events.register<RightClickBlockEvent>(event => {
+    val pos = event.blockPos;
+    val level = event.entity.level;
+    if !level.isClientSide && level.getBlockState(pos).block == <block:minecraft:chest> {
+        val maybeBe = level.getBlockEntity(pos);
+        if maybeBe is BlockEntity && (maybeBe as BlockEntity) is RandomizableContainer {
+            val be as RandomizableContainer = maybeBe as BlockEntity;
+            if <item:minecraft:book>.matches(event.entity.getMainHandItem()) {
+                be.setLootTable(<resource:minecraft:blocks/anvil>);
+            }
+            if be.lootTable != null {
+                println(be.lootTable.location());
+            }
+        }
+    }
 });


### PR DESCRIPTION
This PR adds additional support for containers and related interfaces that are commonly used by block entities.

- RandomizableContainer - Used by blocks that can populate the container from a loot table like chests and dispensers.
- ContainerSingleItem - This container is used by horses, the jukebox, and decorated pots.
- BlockContainerSingleItem - Subtype of ContainerSingleItem that includes access to the BlockEntity. Used by pots and jukeboxes

This PR also includes an update to the dev scripts to test access to RandomizableContainer. This script will print the name of a chests loot table when right clicked, if it has one. It will also set the loot table to the anvil block drops table if the held item is a book.