### PR TITLE
Improved support for decorated pots and their patterns.

### DIFF
--- a/common/src/main/java/com/blamejared/crafttweaker/api/bracket/BracketDumpers.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/api/bracket/BracketDumpers.java
@@ -8,6 +8,7 @@ import com.blamejared.crafttweaker.api.fluid.IFluidStack;
 import com.blamejared.crafttweaker.api.util.ItemStackUtil;
 import com.blamejared.crafttweaker.natives.block.ExpandBlock;
 import com.blamejared.crafttweaker.natives.block.entity.ExpandBannerPattern;
+import com.blamejared.crafttweaker.natives.block.entity.ExpandDecoratedPotPattern;
 import com.blamejared.crafttweaker.natives.component.ExpandDataComponentType;
 import com.blamejared.crafttweaker.natives.entity.ExpandEntityType;
 import com.blamejared.crafttweaker.natives.entity.attribute.ExpandAttribute;
@@ -155,6 +156,13 @@ public class BracketDumpers {
     public static Collection<String> getTrimMaterials() {
         
         return dumpRegistry(Registries.TRIM_MATERIAL, ExpandTrimMaterial::getCommandString);
+    }
+    
+    @ZenCodeType.Method
+    @BracketDumper("decoratedpotpattern")
+    public static Collection<String> getDecoratedPotPatterns() {
+        
+        return dumpRegistry(Registries.DECORATED_POT_PATTERN, ExpandDecoratedPotPattern::getCommandString);
     }
     
 }

--- a/common/src/main/java/com/blamejared/crafttweaker/api/bracket/BracketHandlers.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/api/bracket/BracketHandlers.java
@@ -34,6 +34,7 @@ import net.minecraft.world.item.armortrim.TrimPattern;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BannerPattern;
+import net.minecraft.world.level.block.entity.DecoratedPotPattern;
 import net.minecraft.world.level.block.state.BlockState;
 import org.openzen.zencode.java.ZenCodeType;
 
@@ -153,7 +154,7 @@ public class BracketHandlers {
         return getBlockState(BuiltInRegistries.BLOCK.get(ResourceLocation.parse(name)), properties);
     }
     
-    public static BlockState getBlockState(Block block,  String properties) {
+    public static BlockState getBlockState(Block block, String properties) {
         
         BlockState blockState = block.defaultBlockState();
         if(properties != null && !properties.isEmpty()) {
@@ -437,6 +438,20 @@ public class BracketHandlers {
         
         FloatProviderType<?> registry = getRegistry(tokens, Registries.FLOAT_PROVIDER_TYPE);
         return getRegistry(tokens, Registries.TRIM_MATERIAL);
+    }
+    
+    /**
+     * Gets a decorated pot pattern based on registry name. Throws an exception if it can't find the pattern.
+     *
+     * @param tokens The decorated pot pattern's resource location.
+     *
+     * @return The found decorated pot pattern.
+     */
+    @ZenCodeType.Method
+    @BracketResolver("decoratedpotpattern")
+    public static DecoratedPotPattern getDecoratedPotPattern(String tokens) {
+        
+        return getRegistry(tokens, Registries.DECORATED_POT_PATTERN);
     }
     
 }

--- a/common/src/main/java/com/blamejared/crafttweaker/api/bracket/BracketValidators.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/api/bracket/BracketValidators.java
@@ -263,4 +263,16 @@ public class BracketValidators {
         return validateBracket("trimmaterial", tokens, BracketHandlers::getTrimMaterial);
     }
     
+    @ZenCodeType.Method
+    @BracketValidator("decoratedpotpattern")
+    public static boolean validateDecoratedPotPattern(String tokens) {
+        
+        if(tokens.split(":").length != 2) {
+            CommonLoggers.zenCode()
+                    .error("Invalid Bracket Syntax: <decoratedpotpattern:{}>! Syntax is <decoratedpotpattern:modid:name>", tokens);
+            return false;
+        }
+        
+        return validateBracket("decoratedpotpattern", tokens, BracketHandlers::getDecoratedPotPattern);
+    }
 }

--- a/common/src/main/java/com/blamejared/crafttweaker/api/item/IItemStack.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/api/item/IItemStack.java
@@ -16,7 +16,6 @@ import com.blamejared.crafttweaker.api.ingredient.transformer.IngredientTransfor
 import com.blamejared.crafttweaker.api.ingredient.vanilla.type.IngredientIItemStack;
 import com.blamejared.crafttweaker.api.util.ItemStackUtil;
 import com.blamejared.crafttweaker.api.util.random.Percentaged;
-import com.blamejared.crafttweaker.mixin.common.access.item.AccessItem;
 import com.blamejared.crafttweaker.platform.Services;
 import com.blamejared.crafttweaker_annotations.annotations.Document;
 import com.mojang.datafixers.util.Pair;
@@ -32,6 +31,7 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -41,6 +41,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.entity.DecoratedPotPattern;
+import net.minecraft.world.level.block.entity.DecoratedPotPatterns;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.openzen.zencode.java.ZenCodeType;
@@ -49,7 +51,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
@@ -478,6 +479,22 @@ public interface IItemStack extends IIngredient, IIngredientWithAmount, DataComp
     default int getBurnTime() {
         
         return Services.EVENT.getBurnTime(this);
+    }
+    
+    @ZenCodeType.Method
+    @ZenCodeType.Getter("potPatternId")
+    @ZenCodeType.Nullable
+    default ResourceKey<DecoratedPotPattern> getPotPatternId() {
+        
+        return DecoratedPotPatterns.getPatternFromItem(getInternal().getItem());
+    }
+    
+    @ZenCodeType.Method
+    @ZenCodeType.Getter("potPattern")
+    @ZenCodeType.Nullable
+    default DecoratedPotPattern getPotPattern() {
+        
+        return BuiltInRegistries.DECORATED_POT_PATTERN.get(this.getPotPatternId());
     }
     
     @ZenCodeType.Method

--- a/common/src/main/java/com/blamejared/crafttweaker/natives/block/entity/ExpandDecoratedPotPattern.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/natives/block/entity/ExpandDecoratedPotPattern.java
@@ -1,0 +1,37 @@
+package com.blamejared.crafttweaker.natives.block.entity;
+
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker.platform.Services;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
+import com.blamejared.crafttweaker_annotations.annotations.TaggableElement;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.entity.DecoratedPotPattern;
+import org.openzen.zencode.java.ZenCodeType;
+
+@ZenRegister
+@Document("vanilla/api/block/entity/DecoratedPotPattern")
+@NativeTypeRegistration(value = DecoratedPotPattern.class, zenCodeName = "crafttweaker.api.block.entity.DecoratedPotPattern")
+@TaggableElement("minecraft:decorated_pot_pattern")
+public class ExpandDecoratedPotPattern {
+    
+    /**
+     * Gets the location of the asset used by the pot pattern.
+     *
+     * @return The pot pattern asset ID.
+     */
+    @ZenCodeType.Method
+    @ZenCodeType.Getter("assetId")
+    public static ResourceLocation assetId(DecoratedPotPattern internal) {
+        
+        return internal.assetId();
+    }
+    
+    @ZenCodeType.Getter("commandString")
+    public static String getCommandString(DecoratedPotPattern internal) {
+        
+        return "<decoratedpotpattern:" + Services.REGISTRY.keyOrThrow(Registries.DECORATED_POT_PATTERN, internal) + ">";
+    }
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/natives/block/entity/type/ExpandDecoratedPotBlockEntity.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/natives/block/entity/type/ExpandDecoratedPotBlockEntity.java
@@ -1,0 +1,39 @@
+package com.blamejared.crafttweaker.natives.block.entity.type;
+
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import com.blamejared.crafttweaker_annotations.annotations.NativeTypeRegistration;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.DecoratedPotBlockEntity;
+import net.minecraft.world.level.block.entity.PotDecorations;
+import org.openzen.zencode.java.ZenCodeType;
+
+@ZenRegister
+@Document("vanilla/api/block/entity/type/DecoratedPotBlockEntity")
+@NativeTypeRegistration(value = DecoratedPotBlockEntity.class, zenCodeName = "crafttweaker.api.block.entity.type.DecoratedPotBlockEntity")
+public class ExpandDecoratedPotBlockEntity {
+    
+    /**
+     * Creates a new decorated pot item with a copy of the pots decorations. Additional data like the pots contained item or loot table are not copied.
+     *
+     * @return A new decorated pot item with a copy of the pots decorations.
+     */
+    @ZenCodeType.Method
+    public static ItemStack getPotAsItem(DecoratedPotBlockEntity internal) {
+        
+        return internal.getPotAsItem();
+    }
+    
+    /**
+     * Gets access to the decorations that make up the faces of the pot.
+     *
+     * @return The decorations used by the faces of the pot.
+     */
+    @ZenCodeType.Method
+    @ZenCodeType.Getter("decorations")
+    public static PotDecorations getDecorations(DecoratedPotBlockEntity internal) {
+        
+        return internal.getDecorations();
+    }
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/natives/item/component/ExpandPotDecorations.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/natives/item/component/ExpandPotDecorations.java
@@ -48,7 +48,6 @@ public class ExpandPotDecorations {
         return internal.left().orElse(null);
     }
     
-    @ZenCodeType.Nullable
     @ZenCodeType.Getter("ordered")
     public static List<Item> ordered(PotDecorations internal) {
         

--- a/dev_scripts/events/pot_tests.zs
+++ b/dev_scripts/events/pot_tests.zs
@@ -1,0 +1,24 @@
+#modloader neoforge
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.world.InteractionResultHolder;
+import crafttweaker.neoforge.api.event.interact.RightClickBlockEvent;
+import crafttweaker.api.block.entity.BlockEntity;
+import crafttweaker.api.block.entity.type.DecoratedPotBlockEntity;
+
+events.register<RightClickBlockEvent>(event => {
+    val pos = event.blockPos;
+    val level = event.entity.level;
+    val entity = event.entity;
+    if !level.isClientSide && level.getBlockState(pos).block == <block:minecraft:decorated_pot> {
+        val maybeBe = level.getBlockEntity(pos);
+        if maybeBe is BlockEntity && (maybeBe as BlockEntity) is DecoratedPotBlockEntity {
+            val be = maybeBe as BlockEntity as DecoratedPotBlockEntity;
+            (be.decorations.ordered as crafttweaker.api.item.ItemDefinition[]).each(item => {
+                if <item:minecraft:burn_pottery_sherd>.matches(item) {
+                    entity.drop(be.getPotAsItem(), false);
+                }
+                println(item.commandString);
+            });
+        }
+    }
+});


### PR DESCRIPTION
This PR aims to improve support for working with decorated pots and pot patterns. 

- Fixes PotDecorations.ordered being nullable when results are never null.
- Expose DecoratedPotPattern and added a bracket handler for them.
- Add a way to get the DecoratedPotPattern associated with an item.
- Expose DecoratedPotBlockEntity