### PR TITLE
Add the ability to send data from the server to the client

### DIFF
--- a/common/src/main/java/com/blamejared/crafttweaker/api/action/network/ActionAddDataReceiver.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/api/action/network/ActionAddDataReceiver.java
@@ -1,0 +1,56 @@
+package com.blamejared.crafttweaker.api.action.network;
+
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
+import com.blamejared.crafttweaker.api.action.base.IUndoableAction;
+import com.blamejared.crafttweaker.api.action.internal.CraftTweakerAction;
+import com.blamejared.crafttweaker.api.network.CTNetwork;
+import com.blamejared.crafttweaker.api.network.CTNetworkReceiver;
+import com.blamejared.crafttweaker.api.zencode.IScriptLoadSource;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+
+public class ActionAddDataReceiver extends CraftTweakerAction implements IUndoableAction {
+    
+    private final String id;
+    private final CTNetworkReceiver receiver;
+    
+    public ActionAddDataReceiver(String id, CTNetworkReceiver receiver) {
+        
+        this.id = id;
+        this.receiver = receiver;
+    }
+    
+    @Override
+    public void apply() {
+        
+        CTNetwork.INSTANCE.clientReceivers.computeIfAbsent(id, s -> new ArrayList<>()).add(receiver);
+    }
+    
+    @Override
+    public void undo() {
+        CTNetwork.INSTANCE.clientReceivers.computeIfPresent(id, (s, receivers) -> {
+            receivers.remove(receiver);
+            return receivers.isEmpty() ? null : receivers;
+        });
+    }
+    
+    @Override
+    public String describe() {
+        
+        return "Adding a data receiver with id: " + id;
+    }
+    
+    @Override
+    public String describeUndo() {
+        
+        return "Undoing addition of a data receiver with id: " + id;
+    }
+    
+    @Override
+    public boolean shouldApplyOn(IScriptLoadSource source, Logger logger) {
+        
+        return true;
+    }
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/api/network/CTNetwork.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/api/network/CTNetwork.java
@@ -1,0 +1,105 @@
+package com.blamejared.crafttweaker.api.network;
+
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.action.network.ActionAddDataReceiver;
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker.api.data.IData;
+import com.blamejared.crafttweaker.impl.network.packet.ClientBoundDataPacket;
+import com.blamejared.crafttweaker.platform.Services;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import org.openzen.zencode.java.ZenCodeGlobals;
+import org.openzen.zencode.java.ZenCodeType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Allows scripts to send data from the server to the client.
+ * <br>
+ * This system provides a way for server side scripts to send data to client side only scripts, and trigger events from the server.
+ * <br>
+ * An example of this would be (neoforge only):
+ * <code>
+ * // Listens to the ItemTossEvent
+ * events.register<ItemTossEvent>(event => {
+ *     if event.player is ServerPlayer {
+ *         // If the player is a ServerPlayer, send data to the client using the "toss" id
+ *         network.sendTo(event.player as ServerPlayer, "toss", {custom: "data"});
+ *     }
+ * });
+ * // Using the 'onlyif side client' preprocessor, we can ensure script lines are only ran on the Client distribution.
+ * #onlyif side client
+ * // Listen for data sent to the "toss" id
+ * network.onData("toss", (data, context) => {
+ *      // Prints the data that was received
+ *      println(data.getAsString());
+ * });
+ * #endif
+ * </code>
+ *
+ * @docParam this network
+ */
+@ZenRegister
+@ZenCodeType.Name("crafttweaker.api.network.Network")
+@Document("vanilla/api/network/Network")
+public class CTNetwork {
+    
+    /**
+     * Gets the global network instance
+     */
+    @ZenCodeGlobals.Global("network")
+    public static final CTNetwork INSTANCE = new CTNetwork();
+    
+    public final Map<String, List<CTNetworkReceiver>> clientReceivers = new HashMap<>();
+    
+    private CTNetwork() {}
+    
+    /**
+     * Sends the given data to the specified player on the specified id.
+     *
+     * @param player The player to send the data to.
+     * @param id     A string that connects data receivers with data senders.
+     * @param data   The data to send to the client
+     *
+     * @docParam player player
+     * @docParam id my_notification
+     * @docParam data { custom: "data" }
+     */
+    @ZenCodeType.Method
+    public void sendTo(ServerPlayer player, String id, IData data) {
+        
+        Services.NETWORK.sendPacket(player, new ClientBoundDataPacket(id, data));
+    }
+    
+    /**
+     * Receives data on the client.
+     *
+     * @param id       A string that connects data receivers with data senders.
+     * @param receiver A receiver that is run when the data is received from the server.
+     *
+     * @docParam id my_notification
+     * @docParam receiver (data, context) => println(data.getAsString());
+     */
+    @ZenCodeType.Method
+    public void onData(String id, CTNetworkReceiver receiver) {
+        
+        CraftTweakerAPI.apply(new ActionAddDataReceiver(id, receiver));
+    }
+    
+    public void receive(String id, IData data, Player player) {
+        
+        if(!player.level().isClientSide()) {
+            // Data is limited to Server -> Client right now
+            return;
+        }
+        CTNetworkContext context = new CTNetworkContext(id, player);
+        List<CTNetworkReceiver> receivers = clientReceivers.getOrDefault(id, List.of());
+        for(CTNetworkReceiver receiver : receivers) {
+            receiver.receive(data, context);
+        }
+    }
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/api/network/CTNetworkContext.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/api/network/CTNetworkContext.java
@@ -1,0 +1,49 @@
+package com.blamejared.crafttweaker.api.network;
+
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import net.minecraft.world.entity.player.Player;
+import org.openzen.zencode.java.ZenCodeType;
+
+/**
+ * Context that is provided when data is received from the network.
+ *
+ * @docParam this context
+ */
+@ZenRegister
+@ZenCodeType.Name("vanilla/api/network/NetworkContext")
+@Document("vanilla/api/network/NetworkContext")
+public class CTNetworkContext {
+    
+    private final String id;
+    private final Player player;
+    
+    public CTNetworkContext(String id, Player player) {
+        
+        this.id = id;
+        this.player = player;
+    }
+    
+    /**
+     * The id of the network request.
+     *
+     * @return The id of the network request.
+     */
+    @ZenCodeType.Getter("id")
+    public String id() {
+        
+        return id;
+    }
+    
+    /**
+     * The player that received the network request, this is usually the client player.
+     *
+     * @return The player that received the network request.
+     */
+    @ZenCodeType.Getter("player")
+    public Player player() {
+        
+        return player;
+    }
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/api/network/CTNetworkReceiver.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/api/network/CTNetworkReceiver.java
@@ -1,0 +1,32 @@
+package com.blamejared.crafttweaker.api.network;
+
+import com.blamejared.crafttweaker.api.annotation.ZenRegister;
+import com.blamejared.crafttweaker.api.data.IData;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import org.openzen.zencode.java.ZenCodeType;
+
+/**
+ * A function that is fired when data is received from the network
+ *
+ * An example receiver that just prints the data received would look like this:
+ * <code>
+ * (data, context) => println(data.getAsString());
+ * </code>
+ *
+ * @docParam this receiver
+ */
+@FunctionalInterface
+@ZenRegister
+@ZenCodeType.Name("vanilla/api/network/NetworkReceiver")
+@Document("vanilla/api/network/NetworkReceiver")
+public interface CTNetworkReceiver {
+    
+    /**
+     * Acts on the received data.
+     *
+     * @param data    The data that was received.
+     * @param context information related to the received data.
+     */
+    void receive(IData data, CTNetworkContext context);
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/impl/network/packet/ClientBoundDataPacket.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/impl/network/packet/ClientBoundDataPacket.java
@@ -1,0 +1,39 @@
+package com.blamejared.crafttweaker.impl.network.packet;
+
+import com.blamejared.crafttweaker.api.CraftTweakerConstants;
+import com.blamejared.crafttweaker.api.data.IData;
+import com.blamejared.crafttweaker.api.data.converter.tag.TagToDataConverter;
+import com.blamejared.crafttweaker.api.network.CTNetwork;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Objects;
+
+public record ClientBoundDataPacket(String id, IData data) implements CraftTweakerPacket {
+    
+    public static final ResourceLocation ID = CraftTweakerConstants.rl("data");
+    public static final StreamCodec<RegistryFriendlyByteBuf, ClientBoundDataPacket> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.STRING_UTF8,
+            ClientBoundDataPacket::id,
+            ByteBufCodecs.TAG.map(TagToDataConverter::convert, IData::getInternal),
+            ClientBoundDataPacket::data,
+            ClientBoundDataPacket::new
+    );
+    
+    @Override
+    public void handle() {
+        
+        CTNetwork.INSTANCE.receive(id, data, Objects.requireNonNull(Minecraft.getInstance().player, "Unable to send to a null player"));
+    }
+    
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        
+        return ClientBoundPackets.DATA.type();
+    }
+    
+}

--- a/common/src/main/java/com/blamejared/crafttweaker/impl/network/packet/ClientBoundPackets.java
+++ b/common/src/main/java/com/blamejared/crafttweaker/impl/network/packet/ClientBoundPackets.java
@@ -7,7 +7,9 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 
 public enum ClientBoundPackets {
     COPY(new CustomPacketPayload.Type<>(ClientBoundCopyPacket.ID), ClientBoundCopyPacket.STREAM_CODEC),
-    OPEN_FILE(new CustomPacketPayload.Type<>(ClientBoundSendOpenFileMessagePacket.ID), ClientBoundSendOpenFileMessagePacket.STREAM_CODEC),;
+    OPEN_FILE(new CustomPacketPayload.Type<>(ClientBoundSendOpenFileMessagePacket.ID), ClientBoundSendOpenFileMessagePacket.STREAM_CODEC),
+    DATA(new CustomPacketPayload.Type<>(ClientBoundDataPacket.ID), ClientBoundDataPacket.STREAM_CODEC),
+    ;
     
     private final CustomPacketPayload.Type<CraftTweakerPacket> type;
     private final StreamCodec<RegistryFriendlyByteBuf, CraftTweakerPacket> streamCodec;

--- a/dev_scripts/network/server_to_client.zs
+++ b/dev_scripts/network/server_to_client.zs
@@ -1,0 +1,14 @@
+import crafttweaker.api.entity.type.player.ServerPlayer;
+import crafttweaker.api.world.ItemInteractionResult;
+
+cauldron.addEmptyInteraction(<item:minecraft:diamond_axe>, (blockState, level, pos, player, hand, stack) => {
+    if player is ServerPlayer {
+        println("sending to the client");
+        network.sendTo(player as ServerPlayer, "axed_cauldron", {pos: {x: pos.x, y: pos.y, z: pos.z}});
+    }
+    return ItemInteractionResult.sidedSuccess(level.isClientSide);
+});
+
+network.onData("axed_cauldron", (data, context) => {
+    println(data.getAsString());
+});


### PR DESCRIPTION
Currently this is only server to client, as allowing client -> server would allow clients to spam servers with packets whenever they want.

If we want client -> server we need to figure out ways to ensure that our packets can't be used maliciously (vanilla limits nbt packets to 2MB, maybe we go a lot less?)
