### PR TITLE
Fix CrtStoringErrorLogger dont support null position

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/zenscript/CrtStoringErrorLogger.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/zenscript/CrtStoringErrorLogger.java
@@ -20,20 +20,22 @@ public class CrtStoringErrorLogger extends CrTErrorLogger {
     @Override
     public void error(ZenPosition position, String message) {
         super.error(position, message);
-        errors.add(new SingleError(position.getFileName(), position.getLine(), position.getLineOffset(), message, SingleError.Level.ERROR));
+        if (position != null) errors.add(new SingleError(position.getFileName(), position.getLine(), position.getLineOffset(), message, SingleError.Level.ERROR));
+        else errors.add(new SingleError("null", 0, 0, message, SingleError.Level.ERROR));
     }
     
     @Override
     public void warning(ZenPosition position, String message) {
         super.warning(position, message);
-        errors.add(new SingleError(position.getFileName(), position.getLine(), position.getLineOffset(), message, SingleError.Level.WARN));
-    
+        if (position != null) errors.add(new SingleError(position.getFileName(), position.getLine(), position.getLineOffset(), message, SingleError.Level.WARN));
+        else errors.add(new SingleError("null", 0, 0, message, SingleError.Level.WARN));
     }
     
     @Override
     public void info(ZenPosition position, String message) {
         super.info(position, message);
-        errors.add(new SingleError(position.getFileName(), position.getLine(), position.getLineOffset(), message, SingleError.Level.INFO));
+        if (position != null) errors.add(new SingleError(position.getFileName(), position.getLine(), position.getLineOffset(), message, SingleError.Level.INFO));
+        else errors.add(new SingleError("null", 0, 0, message, SingleError.Level.INFO));
     }
     
 }


### PR DESCRIPTION
```log
[11:05:13] [Client thread/INFO]: [crafttweaker.zenscript.GlobalRegistry:registerNativeClass:101]: java.lang.NullPointerException
[11:05:13] [Client thread/INFO]: [crafttweaker.zenscript.GlobalRegistry:registerNativeClass:101]: 	at crafttweaker.zenscript.CrtStoringErrorLogger.error(CrtStoringErrorLogger.java:23)
[11:05:13] [Client thread/INFO]: [crafttweaker.zenscript.GlobalRegistry:registerNativeClass:101]: 	at stanhebben.zenscript.symbols.SymbolPackage.put(SymbolPackage.java:66)
[11:05:13] [Client thread/INFO]: [crafttweaker.zenscript.GlobalRegistry:registerNativeClass:101]: 	at crafttweaker.zenscript.GlobalRegistry.registerNativeClass(GlobalRegistry.java:99)
```

[Position Should be nullable](https://github.com/CraftTweaker/ZenScript/blob/master/src/main/java/stanhebben/zenscript/impl/GenericErrorLogger.java)
[`            errors.error(null, parts[parts.length - 1] + " is already defined in that package");`](https://github.com/CraftTweaker/ZenScript/blob/master/src/main/java/stanhebben/zenscript/symbols/SymbolPackage.java#L66)
