### PR TITLE
Expand Random for 1.12

### DIFF
--- a/CraftTweaker2-API/src/main/java/crafttweaker/api/util/IRandom.java
+++ b/CraftTweaker2-API/src/main/java/crafttweaker/api/util/IRandom.java
@@ -33,4 +33,7 @@ public interface IRandom {
 
     @ZenMethod
     String getRandomUUID();
+
+    @ZenMethod
+    void setSeed(long seed);
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/util/MCRandom.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/util/MCRandom.java
@@ -56,4 +56,9 @@ public class MCRandom implements IRandom {
     public String getRandomUUID() {
         return MathHelper.getRandomUUID(random).toString();
     }
+
+    @Override
+    public void setSeed(long seed) {
+        random.setSeed(seed);
+    }
 }

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/util/expand/ExpandRandom.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/util/expand/ExpandRandom.java
@@ -1,0 +1,23 @@
+package crafttweaker.mc1120.util.expand;
+
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.util.IRandom;
+import crafttweaker.mc1120.util.MCRandom;
+import stanhebben.zenscript.annotations.ZenExpansion;
+import stanhebben.zenscript.annotations.ZenMethodStatic;
+
+import java.util.Random;
+
+@ZenExpansion("crafttweaker.util.IRandom")
+@ZenRegister
+public class ExpandRandom {
+    @ZenMethodStatic
+    public static IRandom getInstance() {
+        return new MCRandom(new Random());
+    }
+
+    @ZenMethodStatic
+    public static IRandom getInstance(long seed) {
+        return new MCRandom(new Random(seed));
+    }
+}

--- a/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/util/expand/ExpandRandom.java
+++ b/CraftTweaker2-MC1120-Main/src/main/java/crafttweaker/mc1120/util/expand/ExpandRandom.java
@@ -12,11 +12,6 @@ import java.util.Random;
 @ZenRegister
 public class ExpandRandom {
     @ZenMethodStatic
-    public static IRandom getInstance() {
-        return new MCRandom(new Random());
-    }
-
-    @ZenMethodStatic
     public static IRandom getInstance(long seed) {
         return new MCRandom(new Random(seed));
     }


### PR DESCRIPTION
This PR expands support for `IRandom` and adds the following methods:

* `static IRandom getInstance()`: Returns a `MCRandom` instance.
* `static IRandom getInstance(long seed)`: Returns a `MCRandom` instance with the specified seed.
* `void setSeed(long seed)`: Sets the seed for the random instance.

Example:
```zs
import crafttweaker.util.IRandom;

var rd = IRandom.getInstance();
print(rd.nextInt());
rd.setSeed(42);
print(rd.nextInt());
```

In this way, users can obtain a Random instance directly, rather than through `world#random`; in some cases, this might cause confusion.